### PR TITLE
Genericize all the things

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Pantheon Installer
+# Installer
 [![Translation status](https://l10n.elementary.io/widgets/installer/-/svg-badge.svg)](https://l10n.elementary.io/projects/installer/?utm_source=widget)
 [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=46189108)](https://www.bountysource.com/trackers/46189108-elementary-pantheon-installer)
 
 > Note: this is the work-in-progress installer and has not been released yet. For the current installer, see [Ubiquity](https://wiki.ubuntu.com/Ubiquity).
 
-The installer for elementary OS. The installation experience should be attractive and effortless to reassure new users that elementary OS is the right choice. The process should feel safe and should only highlight risk when necessary (e.g. when data will be destroyed). This installer intends to cater to:
+The installer for open-source operating systems. The installation experience should be attractive and effortless to reassure new users that their new OS is the right choice. The process should feel safe and should only highlight risk when necessary (e.g. when data will be destroyed). This installer intends to cater to:
 - New users with no understanding of the nature of an operating system.
 - Average users who want to perform typical installations like dual-boot in a hands-off manner.
 - Expert users who have very specific configuration requirements.


### PR DESCRIPTION
We should change the listings in the README to be more generic, rather than OS-specific, since the new installer will be the standard for linux-based OSs in the future.