### PR TITLE
Change 'system-os-install' to 'system-os-installer' to be generic

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -28,7 +28,7 @@ public class Installer.App : Granite.Application {
         program_name = _("Installer");
         build_version = Build.VERSION;
         app_years = "2016";
-        app_icon = "system-os-install";
+        app_icon = "system-os-installer";
 
         app_launcher = "io.elementary.installer.desktop";
         main_url = "https://launchpad.net/pantheon-installer";

--- a/src/DiskView/DiskView.vala
+++ b/src/DiskView/DiskView.vala
@@ -71,7 +71,7 @@ public class Installer.DiskView : Gtk.Grid {
         var group = new SList<Gtk.RadioButton> ();
         var clean_choice = new ChoiceItem (_("Clean Install"),
                                            _("Erase everything on your device and install a fresh copy of elementary OS."),
-                                           new ThemedIcon ("system-os-install"),
+                                           new ThemedIcon ("system-os-installer"),
                                            null);
         clean_choice.selected.connect ((text) => {
             next_button.label = _("Erase and Install");


### PR DESCRIPTION
The `system-os-install` icon doesn't seem to be standardized, whereas `system-os-installer` is used by a large number of OS installers.