### PR TITLE
Subclass Gtk.Window instead of Dialog

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -18,7 +18,7 @@
  * Authored by: Corentin Noël <corentin@elementary.io>
  */
 
-public class Installer.MainWindow : Gtk.Dialog {
+public class Installer.MainWindow : Gtk.Window {
     private CheckView check_view;
     private Gtk.Stack stack;
 
@@ -36,8 +36,16 @@ public class Installer.MainWindow : Gtk.Dialog {
         stack.add_named (language_view, "language");
         stack.add_named (keyboard_layout_view, "keyboard-layout");
 
+        var titlebar = new Gtk.HeaderBar ();
+
+        var titlebar_style_context = titlebar.get_style_context ();
+        titlebar_style_context.add_class (Gtk.STYLE_CLASS_FLAT);
+        titlebar_style_context.add_class ("default-decoration");
+
+        get_style_context ().add_class ("rounded");
+        set_titlebar (titlebar);
         set_default_geometry (800, 600);
-        get_content_area ().add (stack);
+        add (stack);
 
         check_view.next_step.connect (() => load_diskview ());
         check_view.cancel.connect (() => destroy ());

--- a/src/Views/AbstractInstallerView.vala
+++ b/src/Views/AbstractInstallerView.vala
@@ -34,7 +34,8 @@ public abstract class AbstractInstallerView : Gtk.Grid {
         content_area.orientation = Gtk.Orientation.VERTICAL;
 
         action_area = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL);
-        action_area.margin_end = 10;
+        action_area.margin = 10;
+        action_area.margin_top = 10;
         action_area.spacing = 6;
         action_area.layout_style = Gtk.ButtonBoxStyle.END;
 

--- a/src/Views/CheckView.vala
+++ b/src/Views/CheckView.vala
@@ -218,14 +218,17 @@ public class Installer.CheckView : Gtk.Stack {
                 ignore_button.clicked.connect (() => show_next ());
                 var cancel_button = new Gtk.Button.with_label (_("Cancel Installation"));
                 cancel_button.clicked.connect (() => cancel ());
+
                 var button_grid = new Gtk.Grid ();
                 button_grid.column_homogeneous = true;
                 button_grid.column_spacing = 6;
                 button_grid.halign = Gtk.Align.END;
                 button_grid.valign = Gtk.Align.END;
-                button_grid.margin_end = 6;
+                button_grid.margin = 10;
+                button_grid.margin_top = 10;
                 button_grid.add (cancel_button);
                 button_grid.add (ignore_button);
+
                 var out_grid = new Gtk.Grid ();
                 out_grid.expand = true;
                 out_grid.orientation = Gtk.Orientation.VERTICAL;
@@ -242,14 +245,17 @@ public class Installer.CheckView : Gtk.Stack {
                 ignore_button.clicked.connect (() => show_next ());
                 var cancel_button = new Gtk.Button.with_label (_("Cancel Installation"));
                 cancel_button.clicked.connect (() => cancel ());
+
                 var button_grid = new Gtk.Grid ();
                 button_grid.column_homogeneous = true;
                 button_grid.column_spacing = 6;
                 button_grid.halign = Gtk.Align.END;
                 button_grid.valign = Gtk.Align.END;
-                button_grid.margin_end = 6;
+                button_grid.margin = 10;
+                button_grid.margin_top = 10;
                 button_grid.add (cancel_button);
                 button_grid.add (ignore_button);
+
                 var out_grid = new Gtk.Grid ();
                 out_grid.expand = true;
                 out_grid.orientation = Gtk.Orientation.VERTICAL;

--- a/src/Views/DiskView.vala
+++ b/src/Views/DiskView.vala
@@ -170,10 +170,11 @@ public class Installer.DiskView : Gtk.Grid {
             cancel_button.clicked.connect (() => cancel ());
 
             var button_grid = new Gtk.Grid ();
-            button_grid.margin_end = 12;
             button_grid.column_spacing = 6;
             button_grid.column_homogeneous = true;
             button_grid.halign = Gtk.Align.END;
+            button_grid.margin = 10;
+            button_grid.margin_top = 10;
             button_grid.add (cancel_button);
             button_grid.add (next_button);
             disk_grid.attach (button_grid, 0, 4, 2, 1);


### PR DESCRIPTION
Gets rid of a warning about no transient parent

Fixes #62 