### PR TITLE
Use constants for view names

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -22,6 +22,15 @@ public class Installer.MainWindow : Gtk.Dialog {
     private CheckView check_view;
     private Gtk.Stack stack;
 
+    public const string CHECK_VIEW = "check-view";
+    public const string DISK_VIEW = "disk-view";
+    public const string ERROR_VIEW = "error-view";
+    public const string LANGUAGE_VIEW = "language-view";
+    public const string KEYBOARD_LAYOUT_VIEW = "keyboard-layout-view";
+    public const string PROGRESS_VIEW = "progress-view";
+    public const string SUCCESS_VIEW = "success-view";
+    public const string TRY_INSTALL_VIEW = "try-install-view";
+
     public MainWindow () {
         Object (deletable: false);
     }
@@ -37,12 +46,12 @@ public class Installer.MainWindow : Gtk.Dialog {
 
         stack = new Gtk.Stack ();
         stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
-        stack.add_named (language_view, "language-view");
-        stack.add_named (keyboard_layout_view, "keyboard-layout-view");
-        stack.add_named (progress_view, "progress-view");
-        stack.add_named (try_install_view, "try-install-view");
-        stack.add_named (success_view, "success-view");
-        stack.add_named (error_view, "error-view");
+        stack.add_named (language_view, LANGUAGE_VIEW);
+        stack.add_named (keyboard_layout_view, KEYBOARD_LAYOUT_VIEW);
+        stack.add_named (try_install_view, TRY_INSTALL_VIEW);
+        stack.add_named (progress_view, PROGRESS_VIEW);
+        stack.add_named (success_view, SUCCESS_VIEW);
+        stack.add_named (error_view, ERROR_VIEW);
 
         title = _("Install %s").printf (Utils.get_pretty_name ());
         set_default_geometry (800, 600);
@@ -54,10 +63,10 @@ public class Installer.MainWindow : Gtk.Dialog {
         try_install_view.next_step.connect (() => load_checkview());
         try_install_view.cancel.connect (() => destroy ());
 
-        keyboard_layout_view.next_step.connect (() => stack.set_visible_child_name ("try-install-view"));
+        keyboard_layout_view.next_step.connect (() => stack.set_visible_child_name (TRY_INSTALL_VIEW));
 
         language_view.next_step.connect ((lang) => {
-            stack.set_visible_child_name ("keyboard-layout-view");
+            stack.set_visible_child_name (KEYBOARD_LAYOUT_VIEW);
             keyboard_layout_view.set_language (lang);
         });
     }
@@ -66,20 +75,20 @@ public class Installer.MainWindow : Gtk.Dialog {
         if (check_view.check_requirements ()) {
             load_diskview ();
         } else {
-            stack.add_named (check_view, "check");
-            stack.set_visible_child_name ("check");
+            stack.add_named (check_view, CHECK_VIEW);
+            stack.set_visible_child_name (CHECK_VIEW);
         }
     }
 
     private void load_diskview () {
         var disk_view = new DiskView ();
         disk_view.cancel.connect (() => destroy ());
-        stack.add_named (disk_view, "disk");
-        stack.set_visible_child_name ("disk");
+        stack.add_named (disk_view, DISK_VIEW);
+        stack.set_visible_child_name (DISK_VIEW);
         disk_view.load.begin ();
 
         disk_view.next_step.connect (() => {
-            stack.set_visible_child_name ("progress-view");
+            stack.set_visible_child_name (PROGRESS_VIEW);
         });
     }
 }


### PR DESCRIPTION
So we can't mess up

`public` because we'll want to use these for back buttons