### PR TITLE
KeyboardLayoutView: Stop dialog expanding with wide titles

### DIFF
--- a/src/Views/KeyboardLayoutView.vala
+++ b/src/Views/KeyboardLayoutView.vala
@@ -39,6 +39,8 @@ public class KeyboardLayoutView : AbstractInstallerView {
         back_button.get_style_context ().add_class ("back-button");
 
         var keyboard_layout_list_title = new Gtk.Label (null);
+        keyboard_layout_list_title.ellipsize = Pango.EllipsizeMode.END;
+        keyboard_layout_list_title.max_width_chars = 20;
         keyboard_layout_list_title.use_markup = true;
 
         var keyboard_layout_list_box = new Gtk.ListBox ();
@@ -46,11 +48,17 @@ public class KeyboardLayoutView : AbstractInstallerView {
         keyboard_layout_scrolled.expand = true;
         keyboard_layout_scrolled.add (keyboard_layout_list_box);
 
+        var keyboard_layout_spacer = new Gtk.Grid ();
+
+        var size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
+        size_group.add_widget (back_button);
+        size_group.add_widget (keyboard_layout_spacer);
+
         var keyboard_layout_grid = new Gtk.Grid ();
-        keyboard_layout_grid.column_homogeneous = true;
         keyboard_layout_grid.get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
         keyboard_layout_grid.attach (back_button, 0, 0, 1, 1);
         keyboard_layout_grid.attach (keyboard_layout_list_title, 1, 0, 1, 1);
+        keyboard_layout_grid.attach (keyboard_layout_spacer, 2, 0, 1, 1);
         keyboard_layout_grid.attach (new Gtk.Separator (Gtk.Orientation.HORIZONTAL), 0, 1, 3, 1);
         keyboard_layout_grid.attach (keyboard_layout_scrolled, 0, 2, 3, 1);
 


### PR DESCRIPTION
* Don't use columns homogeneous
* Ellipsize really long titles

Fixes #88 