### PR TITLE
Make back navigation possible

### DIFF
--- a/src/Views/AbstractInstallerView.vala
+++ b/src/Views/AbstractInstallerView.vala
@@ -19,14 +19,16 @@
 public abstract class AbstractInstallerView : Gtk.Grid {
     public signal void cancel ();
     public bool cancellable { get; construct; }
+    public Gtk.Stack navigation_stack { get; construct; }
 
     protected Gtk.Grid content_area;
     protected Gtk.ButtonBox action_area;
 
-    public AbstractInstallerView (bool cancellable = false) {
+    public AbstractInstallerView (Gtk.Stack navigation_stack, bool cancellable = false) {
         Object (
             cancellable: cancellable,
-            row_spacing: 24
+            row_spacing: 24,
+            navigation_stack: navigation_stack
         );
     }
     
@@ -46,7 +48,7 @@ public abstract class AbstractInstallerView : Gtk.Grid {
         if (cancellable) {
             var cancel_button = new Gtk.Button.with_label (_("Cancel Installation"));
             cancel_button.clicked.connect (() => {
-                get_toplevel ().destroy ();
+                navigation_stack.visible_child_name = Installer.MainWindow.TRY_INSTALL_VIEW;
             });
 
             action_area.add (cancel_button);

--- a/src/Views/CheckView.vala
+++ b/src/Views/CheckView.vala
@@ -48,21 +48,23 @@ public class Installer.CheckView : AbstractInstallerView  {
     private Gtk.Button ignore_button;
     private Gtk.Stack stack;
 
+    public CheckView (Gtk.Stack navigation_stack) {
+        Object (
+            cancellable: true,
+            row_spacing: 24,
+            navigation_stack: navigation_stack
+        );
+    }
+
     construct {
         stack = new Gtk.Stack ();
         stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
 
         content_area.add (stack);
 
-        var cancel_button = new Gtk.Button.with_label (_("Cancel Installation"));
-        cancel_button.clicked.connect (() => cancel ());
-
         ignore_button = new Gtk.Button.with_label (_("Ignore"));
         ignore_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
         ignore_button.clicked.connect (() => show_next ());
-
-        action_area.add (cancel_button);
-        show_all ();
     }
 
     // If all the requirements are met, skip this view (return true);

--- a/src/Views/DiskView.vala
+++ b/src/Views/DiskView.vala
@@ -26,8 +26,12 @@ public class Installer.DiskView : AbstractInstallerView {
     private Gtk.ComboBoxText disk_combo;
     private Gtk.Button next_button;
 
-    public DiskView () {
-        Object (cancellable: true);
+    public DiskView (Gtk.Stack navigation_stack) {
+        Object (
+            cancellable: true,
+            row_spacing: 24,
+            navigation_stack: navigation_stack
+        );
     }
 
     construct {
@@ -70,7 +74,6 @@ public class Installer.DiskView : AbstractInstallerView {
         next_button.clicked.connect (() => next_step ());
 
         action_area.add (next_button);
-        show_all ();
     }
 
     // If possible, open devices in a different thread so that the interface stays awake.

--- a/src/Views/ErrorView.vala
+++ b/src/Views/ErrorView.vala
@@ -19,6 +19,13 @@
 public class ErrorView : AbstractInstallerView {
     private Utils.SystemInterface system_interface;
 
+    public ErrorView (Gtk.Stack navigation_stack) {
+        Object (
+            row_spacing: 24,
+            navigation_stack: navigation_stack
+        );
+    }
+
     construct {
         try {
             system_interface = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.login1", "/org/freedesktop/login1");

--- a/src/Views/KeyboardLayoutView.vala
+++ b/src/Views/KeyboardLayoutView.vala
@@ -21,6 +21,13 @@ public class KeyboardLayoutView : AbstractInstallerView {
 
     private Gtk.ListBox input_language_list_box;
 
+    public KeyboardLayoutView (Gtk.Stack navigation_stack) {
+        Object (
+            row_spacing: 24,
+            navigation_stack: navigation_stack
+        );
+    }
+
     construct {
         var image = new Gtk.Image.from_icon_name ("input-keyboard", Gtk.IconSize.DIALOG);
         image.valign = Gtk.Align.END;

--- a/src/Views/LanguageView.vala
+++ b/src/Views/LanguageView.vala
@@ -26,7 +26,12 @@ public class Installer.LanguageView : AbstractInstallerView {
 
     public signal void next_step (string lang);
 
-    public LanguageView () {
+    public LanguageView (Gtk.Stack navigation_stack) {
+        Object (
+            row_spacing: 24,
+            navigation_stack: navigation_stack
+        );
+
         GLib.Timeout.add_seconds (3, timeout);
     }
 

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -17,6 +17,13 @@
  */
 
 public class ProgressView : AbstractInstallerView {
+    public ProgressView (Gtk.Stack navigation_stack) {
+        Object (
+            row_spacing: 24,
+            navigation_stack: navigation_stack
+        );
+    }
+
     construct {
         var logo = new Gtk.Image ();
         logo.icon_name = "distributor-logo-symbolic";

--- a/src/Views/SuccessView.vala
+++ b/src/Views/SuccessView.vala
@@ -19,6 +19,13 @@
 public class SuccessView : AbstractInstallerView {
     private Utils.SystemInterface system_interface;
 
+    public SuccessView (Gtk.Stack navigation_stack) {
+        Object (
+            row_spacing: 24,
+            navigation_stack: navigation_stack
+        );
+    }
+
     construct {
         try {
             system_interface = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.login1", "/org/freedesktop/login1");

--- a/src/Views/TryInstallView.vala
+++ b/src/Views/TryInstallView.vala
@@ -19,6 +19,13 @@
 public class TryInstallView : AbstractInstallerView {
     public signal void next_step ();
 
+    public TryInstallView (Gtk.Stack navigation_stack) {
+        Object (
+            row_spacing: 24,
+            navigation_stack: navigation_stack
+        );
+    }
+
     construct {
         var title_label = new Gtk.Label (_("Install %s").printf (Utils.get_pretty_name ()));
         title_label.wrap = true;


### PR DESCRIPTION
* Pass the navigation stack into each view so that we can navigate to other pages
* Make sure we don't add the check view or disk view to the stack more than once
* Go back to the TryInstall view when we "Cancel Installation"

Fixes #126 
Fixes #86 