### PR TITLE
Use non-symbolic distributor-logo icon

### DIFF
--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -22,7 +22,7 @@ public class ProgressView : AbstractInstallerView {
 
     construct {
         var logo = new Gtk.Image ();
-        logo.icon_name = "distributor-logo-symbolic";
+        logo.icon_name = "distributor-logo";
         logo.pixel_size = 128;
 
         var terminal_output = new Gtk.Frame (null);


### PR DESCRIPTION
Sets ProgressView to use the non-symbolic distributor logo by default, since that's maybe more generic and -symbolic can be set in the stylesheet.