### PR TITLE
Use wider width_request to help correct proportions on other stylesheets

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -37,7 +37,7 @@ public class Installer.MainWindow : Gtk.Dialog {
             icon_name: "system-os-installer",
             resizable: false,
             title: _("Install %s").printf (Utils.get_pretty_name ()),
-            width_request: 800
+            width_request: 950
         );
     }
 


### PR DESCRIPTION
In Pop GTK, the window is very narrow and tall for some reason. This appears to help ease the proportions a bit and keeps the window from being narrower than it is tall.