### PR TITLE
Put the null check in it's right place

### DIFF
--- a/src/Views/LanguageView.vala
+++ b/src/Views/LanguageView.vala
@@ -173,10 +173,10 @@ public class Installer.LanguageView : AbstractInstallerView {
         if (row == null) {
             select_number = 0;
             row = lang_variant_widget.main_listbox.get_row_at_index (select_number);
-        }
 
-        if (row == null) {
-            return Source.REMOVE;
+            if (row == null) {
+                return Source.REMOVE;
+            }
         }
 
         var current_lang = Environment.get_variable ("LANGUAGE");


### PR DESCRIPTION
There was a small mistake in https://github.com/elementary/installer/pull/178 with the `if` condition being in the wrong place and the installer would check if `row` is `null` twice unnecessarily. This shouldn't change how the application behaves, it's only a small optimization.