### PR TITLE
Add Terminal css

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -1,0 +1,22 @@
+/*-
+ * Copyright (c) 2017 elementary LLC. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+textview.terminal {
+    background-color: #252e32;
+    color: #94a3a5;
+    padding: 12px;
+}

--- a/data/application.css
+++ b/data/application.css
@@ -18,5 +18,9 @@
 textview.terminal {
     background-color: #252e32;
     color: #94a3a5;
-    padding: 12px;
+}
+
+textview.terminal selection {
+    background-color: #93a1a1;
+    color: #252e32; 
 }

--- a/data/io.elementary.installer.gresource.xml
+++ b/data/io.elementary.installer.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/io/elementary/installer">
+    <file alias="application.css" compressed="true">application.css</file>
+  </gresource>
+</gresources>

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,12 @@ dependencies = [
     gnome_keyboard_ui_dep
 ]
 
+asresources = gnome.compile_resources(
+    'as-resources', 'data/' + meson.project_name() + '.gresource.xml',
+    source_dir: 'data',
+    c_name: 'as'
+)
+
 subdir('po')
 subdir('src')
 subdir('data')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -29,6 +29,10 @@ public class Installer.App : Gtk.Application {
         var window = new MainWindow ();
         window.show_all ();
         this.add_window (window);
+
+        var css_provider = new Gtk.CssProvider ();
+        css_provider.load_from_resource ("io/elementary/installer/application.css");
+        Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
     }
 }
 

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -32,6 +32,7 @@ public class ProgressView : AbstractInstallerView {
 
         unowned LogHelper log_helper = LogHelper.get_default ();
         var terminal_view = new Gtk.TextView.with_buffer (log_helper.buffer);
+        terminal_view.bottom_margin = terminal_view.top_margin = terminal_view.left_margin = terminal_view.right_margin = 12;
         terminal_view.editable = false;
         terminal_view.cursor_visible = true;
         terminal_view.monospace = true;

--- a/src/meson.build
+++ b/src/meson.build
@@ -39,5 +39,6 @@ config_file = configure_file(
 )
 
 executable(meson.project_name(), vala_files, config_file,
+           asresources,
            dependencies : dependencies,
            install: true)


### PR DESCRIPTION
Fixes #199 

This adds an application priority stylesheet to style the Terminal. Application priority means that the system stylesheet cannot overwrite it. However, fallback priority just means it gets overwritten by `textview.view` so it doesn't really do anything meaningful as a fallback style.

If System76 wants to change this style, we can either move this into our CSS or they'll need to carry a patch for this CSS file

![screenshot from 2017-10-16 15 24 56](https://user-images.githubusercontent.com/7277719/31638004-2ec7d260-b286-11e7-81b4-06ba09c0bb3f.png)
