### PR TITLE
Rename distinst config member from drive to disk

### DIFF
--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -89,7 +89,7 @@ public class ProgressView : AbstractInstallerView {
         unowned Configuration current_config = Configuration.get_default ();
         config.squashfs = Build.SQUASHFS_PATH;
         // Here the API want us to provide "sda" instead of "/dev/sda"
-        config.drive = current_config.disk.replace ("/dev/", "");
+        config.disk = current_config.disk.replace ("/dev/", "");
         new Thread<void*> (null, () => {
             installer.install (config);
             return null;


### PR DESCRIPTION
This is done to match a change in distinst which means that the same terminology is now used in both the installer GUI and distinst backend: https://github.com/pop-os/distinst/blob/master/src/distinst.vapi#L17

This will require a new version of distinst, which will also give you automatic unmount and swapoff of any partitions the installer will attempt to utilize.

I believe the failure to swapoff may be the cause of installation failures experienced by @codygarver 