### PR TITLE
Update distinst

### DIFF
--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -89,7 +89,7 @@ public class ProgressView : AbstractInstallerView {
         unowned Configuration current_config = Configuration.get_default ();
         config.squashfs = Build.SQUASHFS_PATH;
         // Here the API want us to provide "sda" instead of "/dev/sda"
-        config.drive = current_config.disk.replace ("/dev/", "");
+        config.disk = current_config.disk.replace ("/dev/", "");
         new Thread<void*> (null, () => {
             installer.install (config);
             return null;


### PR DESCRIPTION
This updates to the 0.2 version of distinst, which:
- Fixes the log handler, finally filling the log window with data
- Changes the name of the config entry from `drive` to `disk`