### PR TITLE
Fix blank keyboard widget

### DIFF
--- a/src/Widgets/LayoutWidget.vala
+++ b/src/Widgets/LayoutWidget.vala
@@ -23,7 +23,7 @@ public class LayoutWidget : Gtk.Grid {
     static Gkbd.KeyboardDrawingGroupLevel top_right = { 0, 3 };
     static Gkbd.KeyboardDrawingGroupLevel bottom_left = { 0, 0 };
     static Gkbd.KeyboardDrawingGroupLevel bottom_right = { 0, 2 };
-    Gkbd.KeyboardDrawingGroupLevel*[] group = { &top_left, &top_right, &bottom_left, &bottom_right };
+    static Gkbd.KeyboardDrawingGroupLevel*[] group = { &top_left, &top_right, &bottom_left, &bottom_right };
 
     construct {
         gkbd_drawing = new Gkbd.KeyboardDrawing ();

--- a/src/Widgets/LayoutWidget.vala
+++ b/src/Widgets/LayoutWidget.vala
@@ -19,32 +19,18 @@
 public class LayoutWidget : Gtk.Grid {
     private Gkbd.KeyboardDrawing gkbd_drawing;
 
-    static Gkbd.KeyboardDrawingGroupLevel top_left = Gkbd.KeyboardDrawingGroupLevel ();
-    static Gkbd.KeyboardDrawingGroupLevel top_right = Gkbd.KeyboardDrawingGroupLevel ();
-    static Gkbd.KeyboardDrawingGroupLevel bottom_left = Gkbd.KeyboardDrawingGroupLevel ();
-    static Gkbd.KeyboardDrawingGroupLevel bottom_right = Gkbd.KeyboardDrawingGroupLevel ();
-    static (unowned Gkbd.KeyboardDrawingGroupLevel)[] group = {top_left, top_right, bottom_left, bottom_right};
-
-    static construct {
-        top_left.group = 0;
-        top_left.level = 1;
-
-        top_right.group = 0;
-        top_right.level = 3;
-
-        bottom_left.group = 0;
-        bottom_left.level = 0;
-
-        bottom_right.group = 0;
-        bottom_right.level = 2;
-    }
+    static Gkbd.KeyboardDrawingGroupLevel top_left = { 0, 1 };
+    static Gkbd.KeyboardDrawingGroupLevel top_right = { 0, 3 };
+    static Gkbd.KeyboardDrawingGroupLevel bottom_left = { 0, 0 };
+    static Gkbd.KeyboardDrawingGroupLevel bottom_right = { 0, 2 };
+    Gkbd.KeyboardDrawingGroupLevel*[] group = { &top_left, &top_right, &bottom_left, &bottom_right };
 
     construct {
         gkbd_drawing = new Gkbd.KeyboardDrawing ();
         gkbd_drawing.parent = this;
         width_request = 600;
         height_request = 230;
-        gkbd_drawing.set_groups_levels (group);
+        gkbd_drawing.set_groups_levels (((unowned Gkbd.KeyboardDrawingGroupLevel)[])group);
         set_layout ("gb\tcolemak");
         gkbd_drawing.show_all ();
     }
@@ -54,13 +40,12 @@ public class LayoutWidget : Gtk.Grid {
     }
 
     public override bool draw (Cairo.Context cr) {
-        var scale_factor = get_scale_factor ();
         gkbd_drawing.render (cr,
         Pango.cairo_create_layout (cr), 0, 0,
             get_allocated_width (),
             get_allocated_height (),
-            scale_factor,
-            scale_factor
+            50,
+            50
         );
         return true;
     }


### PR DESCRIPTION
Fixes #65 

We were getting a blank keyboard layout for a couple of reasons:

1. The last arguments to `gkbd_drawing.render` were DPI not scale factor, it looks like they are hardcoded to 50 when using the dialog version of this widget, so do the same: https://github.com/GNOME/libgnomekbd/blob/master/libgnomekbd/gkbd-keyboard-drawing.c#L1542
2. The Vala compiler is doing something to that array and passing it in a format that `libgnomekbd` doesn't want. I re-wrote it to be how I'd expect it to work in C and it seems to have fixed it, but it's not pretty. If anyone knows how better to translate that to Vala without the keyboard disappearing again or it crashing, be my guest.