### PR TITLE
Fix double free of Disks pointer

### DIFF
--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -284,7 +284,7 @@ public class ProgressView : AbstractInstallerView {
         }
 
         new Thread<void*> (null, () => {
-            installer.install (disks, config);
+            installer.install ((owned) disks, config);
             return null;
         });
     }


### PR DESCRIPTION
Fixes an issue that causes the installer to crash after the `Installer.install()` method is used, due to `install()` taking ownership of `disks`, then Vala also trying to free it.