### PR TITLE
Implement Better Terminal Behavior

### DIFF
--- a/src/Helpers/LogHelper.vala
+++ b/src/Helpers/LogHelper.vala
@@ -60,7 +60,7 @@ public class LogHelper : GLib.Object {
         Idle.add (() => {
             Gtk.TextIter end_iter;
             buffer.get_end_iter (out end_iter);
-            string new_line = level_name (level) + ": " + message + "\n";
+            string new_line = "\n" + level_name (level) + ": " + message;
             buffer.insert (ref end_iter, new_line, new_line.length);
             return GLib.Source.REMOVE;
         });

--- a/src/Helpers/LogHelper.vala
+++ b/src/Helpers/LogHelper.vala
@@ -58,7 +58,10 @@ public class LogHelper : GLib.Object {
     private void log_func (Distinst.LogLevel level, string message) {
         stdout.printf("log: %s: %s\n", level_name(level), message);
         Idle.add (() => {
-            buffer.text += level_name(level) + ": " + message + "\n";
+            Gtk.TextIter end_iter;
+            buffer.get_end_iter (out end_iter);
+            string new_line = level_name (level) + ": " + message + "\n";
+            buffer.insert(ref end_iter, new_line, new_line.length);
             return GLib.Source.REMOVE;
         });
     }

--- a/src/Helpers/LogHelper.vala
+++ b/src/Helpers/LogHelper.vala
@@ -61,7 +61,7 @@ public class LogHelper : GLib.Object {
             Gtk.TextIter end_iter;
             buffer.get_end_iter (out end_iter);
             string new_line = level_name (level) + ": " + message + "\n";
-            buffer.insert(ref end_iter, new_line, new_line.length);
+            buffer.insert (ref end_iter, new_line, new_line.length);
             return GLib.Source.REMOVE;
         });
     }

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -20,7 +20,6 @@ public class ProgressView : AbstractInstallerView {
     public signal void on_success ();
     public signal void on_error ();
 
-    private bool overshot;
     private double prev_upper_adj = 0;
     private Gtk.ScrolledWindow terminal_output;
     public Gtk.TextView terminal_view { get; construct; }

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -318,7 +318,6 @@ public class ProgressView : AbstractInstallerView {
         }
 
         new Thread<void*> (null, () => {
-            GLib.Thread.usleep (3000000);
             installer.install ((owned) disks, config);
             return null;
         });

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -20,6 +20,7 @@ public class ProgressView : AbstractInstallerView {
     public signal void on_success ();
     public signal void on_error ();
 
+    private Gtk.ScrolledWindow terminal_output;
     private Gtk.ProgressBar progressbar;
     private Gtk.Label progressbar_label;
     private const int NUM_STEP = 5;
@@ -39,7 +40,7 @@ public class ProgressView : AbstractInstallerView {
         terminal_view.wrap_mode = Gtk.WrapMode.WORD_CHAR;
         terminal_view.get_style_context ().add_class ("terminal");
 
-        var terminal_output = new Gtk.ScrolledWindow (null, null);
+        terminal_output = new Gtk.ScrolledWindow (null, null);
         terminal_output.hscrollbar_policy = Gtk.PolicyType.NEVER;
         terminal_output.expand = true;
         terminal_output.add (terminal_view);
@@ -73,12 +74,29 @@ public class ProgressView : AbstractInstallerView {
         terminal_button.toggled.connect (() => {
             if (terminal_button.active) {
                 logo_stack.visible_child = terminal_output;
+                scroll_to_bottom ();
             } else {
                 logo_stack.visible_child = logo;
             }
         });
 
+        terminal_view.size_allocate.connect (() => {
+            if (terminal_is_at_bottom ()) {
+                scroll_to_bottom ();
+            }
+        });
+
         show_all ();
+    }
+
+    private void scroll_to_bottom () {
+        var adj = terminal_output.vadjustment;
+        adj.value = adj.upper;
+    }
+
+    private bool terminal_is_at_bottom () {
+        var adj = terminal_output.vadjustment;
+        return adj.upper - adj.page_size - adj.value <= 50;
     }
 
     // TODO: This should receive the disk configuration from the user.


### PR DESCRIPTION
Closes #227

- Makes a change to how the log buffer is handled. Concatenating text to the buffer directly causes the text view to reset, losing the scrolled position. Instead, using the `insert` method on the buffer allows the existing text contents to be retained, and new contents inserted at the end.
- The terminal button will now automatically scroll to the bottom of the view when the inner text view is updated, and the view was previously at the bottom.