### PR TITLE
Travis: Use vala-lint container from Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ services:
 env:
  - DEPENDENCY_PACKAGES="meson desktop-file-utils gettext libdistinst-dev libgtk-3-dev libgee-0.8-dev libgranite-dev libxml2-dev libjson-glib-dev libgnomekbd-dev libpwquality-dev libxml2-utils valac"
 
-install:
- - docker build -t vala-lint github.com/elementary/docker#master:vala-lint
-
 script:
- - docker run -v "$PWD":/var/opt/vala-lint vala-lint
+ - docker run -v "$PWD":/var/opt/vala-lint elementary/docker:vala-lint
  - docker run -v "$PWD":/tmp/build-dir elementary/docker:juno-unstable /bin/sh -c "apt-get update && apt-get -y dist-upgrade && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && meson build --prefix=/usr && ninja -C build test"


### PR DESCRIPTION
Avoids random Travis failures.