### PR TITLE
Just skip the install in test mode

### DIFF
--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -317,7 +317,12 @@ public class ProgressView : AbstractInstallerView {
         }
 
         new Thread<void*> (null, () => {
-            installer.install ((owned) disks, config);
+            if (Installer.App.test_mode) {
+                on_success ();
+            } else {
+                installer.install ((owned) disks, config);
+            }
+
             return null;
         });
     }


### PR DESCRIPTION
Minimally-invasive way to fix #290. Doesn't yet allow us to actually test the progress view (could probably just add a fake timout or something for that), but avoids nuking drives.