### PR TITLE
Shorten disk title and change to title case

### DIFF
--- a/src/Views/DiskView.vala
+++ b/src/Views/DiskView.vala
@@ -48,7 +48,7 @@ public class Installer.DiskView : AbstractInstallerView {
         var install_image = new Gtk.Image.from_icon_name ("system-os-installer", Gtk.IconSize.DIALOG);
         install_image.valign = Gtk.Align.START;
 
-        var install_label = new Gtk.Label (_("Select a drive to use for installation"));
+        var install_label = new Gtk.Label (_("Select a Drive"));
         install_label.hexpand = true;
         install_label.get_style_context ().add_class ("h2");
 


### PR DESCRIPTION
One-liner; helps prevent the view from growing, plus makes it more consistent with the other views.