### PR TITLE
Use GLib.Error instead of IOError to fix warnings

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -51,14 +51,14 @@ namespace Utils {
 
     [DBus (name = "org.freedesktop.login1.Manager")]
     interface SystemInterface : Object {
-        public abstract void reboot (bool interactive) throws IOError;
-        public abstract void power_off (bool interactive) throws IOError;
+        public abstract void reboot (bool interactive) throws GLib.Error;
+        public abstract void power_off (bool interactive) throws GLib.Error;
     }
 
     [DBus (name = "org.freedesktop.DisplayManager.Seat")]
     public interface SeatInterface : Object {
         public abstract bool has_guest_account { get; }
-        public abstract void switch_to_guest (string session_name) throws IOError;
+        public abstract void switch_to_guest (string session_name) throws GLib.Error;
     }
 
     private static SeatInterface? seat_instance;
@@ -66,7 +66,7 @@ namespace Utils {
         if (seat_instance == null) {
             try {
                 seat_instance = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.DisplayManager", Environment.get_variable ("XDG_SEAT_PATH"), DBusProxyFlags.NONE);
-            } catch (IOError e) {
+            } catch (GLib.Error e) {
                 critical ("DisplayManager.Seat error: %s", e.message);
             }
         }


### PR DESCRIPTION
Cassidy's branch #313 will make it easier to fix the new warnings about not catching the error. For now this branch just solves the warning about not using IOError