### PR TITLE
Create Widgets/Terminal

### DIFF
--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -20,7 +20,7 @@ public class ProgressView : AbstractInstallerView {
     public signal void on_success ();
     public signal void on_error ();
 
-    public Terminal terminal_view { get; construct; }
+    public Installer.Terminal terminal_view { get; construct; }
     private Gtk.ProgressBar progressbar;
     private Gtk.Label progressbar_label;
     private const int NUM_STEP = 5;
@@ -32,7 +32,7 @@ public class ProgressView : AbstractInstallerView {
         logo.get_style_context ().add_class ("logo");
 
         unowned LogHelper log_helper = LogHelper.get_default ();
-        terminal_view = new Terminal (log_helper.buffer);
+        terminal_view = new Installer.Terminal (log_helper.buffer);
 
         var logo_stack = new Gtk.Stack ();
         logo_stack.transition_type = Gtk.StackTransitionType.OVER_UP_DOWN;

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -20,9 +20,7 @@ public class ProgressView : AbstractInstallerView {
     public signal void on_success ();
     public signal void on_error ();
 
-    private double prev_upper_adj = 0;
-    private Gtk.ScrolledWindow terminal_output;
-    public Gtk.TextView terminal_view { get; construct; }
+    public Terminal terminal_view { get; construct; }
     private Gtk.ProgressBar progressbar;
     private Gtk.Label progressbar_label;
     private const int NUM_STEP = 5;
@@ -34,23 +32,12 @@ public class ProgressView : AbstractInstallerView {
         logo.get_style_context ().add_class ("logo");
 
         unowned LogHelper log_helper = LogHelper.get_default ();
-        terminal_view = new Gtk.TextView.with_buffer (log_helper.buffer);
-        terminal_view.bottom_margin = terminal_view.top_margin = terminal_view.left_margin = terminal_view.right_margin = 12;
-        terminal_view.editable = false;
-        terminal_view.cursor_visible = true;
-        terminal_view.monospace = true;
-        terminal_view.wrap_mode = Gtk.WrapMode.WORD_CHAR;
-        terminal_view.get_style_context ().add_class (Granite.STYLE_CLASS_TERMINAL);
-
-        terminal_output = new Gtk.ScrolledWindow (null, null);
-        terminal_output.hscrollbar_policy = Gtk.PolicyType.NEVER;
-        terminal_output.expand = true;
-        terminal_output.add (terminal_view);
+        terminal_view = new Terminal (log_helper.buffer);
 
         var logo_stack = new Gtk.Stack ();
         logo_stack.transition_type = Gtk.StackTransitionType.OVER_UP_DOWN;
         logo_stack.add (logo);
-        logo_stack.add (terminal_output);
+        logo_stack.add (terminal_view);
 
         var terminal_button = new Gtk.ToggleButton ();
         terminal_button.halign = Gtk.Align.END;
@@ -75,37 +62,14 @@ public class ProgressView : AbstractInstallerView {
 
         terminal_button.toggled.connect (() => {
             if (terminal_button.active) {
-                logo_stack.visible_child = terminal_output;
-                scroll_to_bottom ();
+                logo_stack.visible_child = terminal_view;
+                terminal_view.attempt_scroll ();
             } else {
                 logo_stack.visible_child = logo;
             }
         });
 
-        terminal_view.size_allocate.connect (() => attempt_scroll ());
-
         show_all ();
-    }
-
-    private void attempt_scroll () {
-        var adj = terminal_output.vadjustment;
-
-        var units_from_end = prev_upper_adj - adj.page_size - adj.value;
-        var view_size_difference = adj.upper - prev_upper_adj;
-        if (view_size_difference < 0) {
-            view_size_difference = 0;
-        }
-
-        if (prev_upper_adj <= adj.page_size || units_from_end <= 50) {
-            scroll_to_bottom ();
-        }
-
-        prev_upper_adj = adj.upper;
-    }
-
-    private void scroll_to_bottom () {
-        var adj = terminal_output.vadjustment;
-        adj.value = adj.upper;
     }
 
     public string get_log () {

--- a/src/Widgets/Terminal.vala
+++ b/src/Widgets/Terminal.vala
@@ -1,0 +1,76 @@
+/*-
+ * Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Michael Aaron Murphy <michael@system76.com>
+ */
+
+public class Terminal : Gtk.ScrolledWindow {
+    public Gtk.TextBuffer buffer { get; construct; }
+
+    private Gtk.TextView view;
+    private double prev_upper_adj = 0;
+
+    public string log {
+        owned get {
+            return view.buffer.text;
+        }
+    }
+
+    public signal void toggled (bool active);
+
+    public Terminal (Gtk.TextBuffer buffer) {
+        Object (buffer: buffer);
+    }
+
+    construct {
+        view = new Gtk.TextView.with_buffer (buffer);
+        view.editable = false;
+        view.cursor_visible = true;
+        view.monospace = true;
+        view.wrap_mode = Gtk.WrapMode.WORD_CHAR;
+        view.expand = true;
+
+        // A workaround for https://gitlab.gnome.org/GNOME/gtk/issues/628
+        var workaround_box = new Gtk.Grid ();
+        workaround_box.margin = 12;
+        workaround_box.expand = true;
+        workaround_box.add (view);
+
+        hscrollbar_policy = Gtk.PolicyType.NEVER;
+        expand = true;
+        add (workaround_box);
+        get_style_context ().add_class (Granite.STYLE_CLASS_TERMINAL);
+
+        view.size_allocate.connect (() => attempt_scroll ());
+    }
+
+    public void attempt_scroll () {
+        var adj = vadjustment;
+
+        var units_from_end = prev_upper_adj - adj.page_size - adj.value;
+        var view_size_difference = adj.upper - prev_upper_adj;
+        if (view_size_difference < 0) {
+            view_size_difference = 0;
+        }
+
+        if (prev_upper_adj <= adj.page_size || units_from_end <= 50) {
+            adj.value = adj.upper;
+        }
+
+        prev_upper_adj = adj.upper;
+    }
+}
+

--- a/src/Widgets/Terminal.vala
+++ b/src/Widgets/Terminal.vala
@@ -17,7 +17,7 @@
  * Authored by: Michael Aaron Murphy <michael@system76.com>
  */
 
-public class Terminal : Gtk.ScrolledWindow {
+public class Installer.Terminal : Gtk.ScrolledWindow {
     public Gtk.TextBuffer buffer { get; construct; }
 
     private Gtk.TextView view;

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,6 +28,7 @@ vala_files = [
     'Widgets/LayoutWidget.vala',
     'Widgets/PartitionBar.vala',
     'Widgets/PartitionMenu.vala',
+    'Widgets/Terminal.vala',
     'Widgets/VariantWidget.vala'
 ]
 


### PR DESCRIPTION
Breaks the Terminal out into its own widget as in #346 so that we can use it in other views in future commits

Fixes #257 