### PR TITLE
application.css: Remove terminal class and add primary

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -15,12 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-textview.terminal {
-    background-color: #252e32;
-    color: #94a3a5;
-}
-
-textview.terminal selection {
-    background-color: #93a1a1;
-    color: #252e32; 
+.primary {
+    font-weight: 700;
+    font-size: 1.2em;
 }


### PR DESCRIPTION
The Terminal CSS is now upstream in the stylesheet. Styles for `.primary` need to be added since this is no longer a dialog subclass