### PR TITLE
Revert "session: divert undesirable autostart"

### DIFF
--- a/debian/io.elementary.installer-session.postrm
+++ b/debian/io.elementary.installer-session.postrm
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-if [ "$1" = remove ] ; then
-	dpkg-divert --remove --rename --package io.elementary.installer-session --divert /etc/xdg/autostart/io.elementary.onboarding.desktop.distrib /etc/xdg/autostart/io.elementary.onboarding.desktop
-fi

--- a/debian/io.elementary.installer-session.preinst
+++ b/debian/io.elementary.installer-session.preinst
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-if [ "$1" = install ] || [ "$1" = upgrade ] ; then
-	dpkg-divert --add --rename --package io.elementary.installer-session --divert /etc/xdg/autostart/io.elementary.onboarding.desktop.distrib /etc/xdg/autostart/io.elementary.onboarding.desktop
-fi


### PR DESCRIPTION
This reverts commit d0a297cc251d2a35c87efcbe80f2c958545f858d.

Shouldn't be necessary now after https://github.com/elementary/onboarding/commit/36f0777b7823e214acf75aab67ed9c56471c0931