### PR TITLE
TryInstallView: remove shutdown button

### DIFF
--- a/src/Views/TryInstallView.vala
+++ b/src/Views/TryInstallView.vala
@@ -71,10 +71,6 @@ public class Installer.TryInstallView : AbstractInstallerView {
         next_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
         next_button.sensitive = false;
 
-        var shutdown_button = new Gtk.Button.from_icon_name ("system-shutdown-symbolic", Gtk.IconSize.BUTTON);
-        shutdown_button.tooltip_text = _("Shut Down");
-        shutdown_button.get_style_context ().add_class ("circular");
-
         var demo_button = new InstallTypeButton (
             _("Try Demo Mode"),
             "dialog-question",
@@ -93,11 +89,8 @@ public class Installer.TryInstallView : AbstractInstallerView {
             _("Create, resize, or otherwise manage partitions manually. This method may lead to data loss.")
         );
 
-        action_area.add (shutdown_button);
         action_area.add (back_button);
         action_area.add (next_button);
-        action_area.set_child_secondary (shutdown_button, true);
-        action_area.set_child_non_homogeneous (shutdown_button, true);
 
         type_grid.add (demo_button);
         type_grid.add (clean_install_button);


### PR DESCRIPTION
We don't need this now that we run the panel in the installer session