### PR TITLE
Use casper hook to autostart installer

### DIFF
--- a/debian/99elementary-installer
+++ b/debian/99elementary-installer
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+PREREQ=""
+DESCRIPTION="Adding installer hooks..."
+
+prereqs()
+{
+       echo "$PREREQ"
+}
+
+case $1 in
+# get pre-requisites
+prereqs)
+       prereqs
+       exit 0
+       ;;
+esac
+
+. /scripts/casper-functions
+
+log_begin_msg "$DESCRIPTION"
+
+APP="io.elementary.installer"
+
+chroot /root install -d -o "$USERNAME" -g "$USERNAME" \
+    "/home/$USERNAME/.config/autostart/"
+
+chroot /root install -D -o "$USERNAME" -g "$USERNAME" \
+    "/usr/share/applications/$APP.desktop" \
+    "/home/$USERNAME/.config/autostart/$APP.desktop"
+
+log_end_msg

--- a/debian/control
+++ b/debian/control
@@ -33,3 +33,10 @@ Depends: io.elementary.installer, lightdm
 Recommends: elementary-default-settings
 Description: Dedicated installer session
  Launches io.elementary.installer in a dedicated session.
+
+Package: io.elementary.installer-casper
+Architecture: amd64
+Priority: extra
+Depends: casper
+Description: Autostart installer in casper
+ Autostart installer when running in a live system with casper

--- a/debian/io.elementary.installer-casper.install
+++ b/debian/io.elementary.installer-casper.install
@@ -1,0 +1,1 @@
+debian/99pop-installer usr/share/initramfs-tools/scripts/casper-bottom/

--- a/debian/io.elementary.installer-casper.install
+++ b/debian/io.elementary.installer-casper.install
@@ -1,1 +1,1 @@
-debian/99pop-installer usr/share/initramfs-tools/scripts/casper-bottom/
+debian/99elementary-installer usr/share/initramfs-tools/scripts/casper-bottom/

--- a/debian/io.elementary.installer-casper.triggers
+++ b/debian/io.elementary.installer-casper.triggers
@@ -1,0 +1,1 @@
+activate-noawait update-initramfs

--- a/debian/io.elementary.installer-session.install
+++ b/debian/io.elementary.installer-session.install
@@ -1,4 +1,2 @@
-debian/lightdm.conf /etc/lightdm/
 usr/share/gnome-session
 usr/share/xsessions
-etc/xdg/autostart

--- a/debian/io.elementary.installer-session.install
+++ b/debian/io.elementary.installer-session.install
@@ -1,2 +1,3 @@
 usr/share/gnome-session
 usr/share/xsessions
+etc/xdg/autostart

--- a/debian/lightdm.conf
+++ b/debian/lightdm.conf
@@ -1,6 +1,0 @@
-[Seat:*]
-allow-guest=true
-autologin-guest=false
-autologin-user=elementary
-autologin-user-timeout=0
-autologin-session=installer


### PR DESCRIPTION
This changes the `deb-packaging` branch to not overwrite the `lightdm.conf` for the purposes of starting the installer.

We can use `casper`, the tool that autoconfigures users and autologin etc when running in a live session to install the `.desktop` file to the live user's autostart directory. Also helps in the case where someone accidentally installs the installer into their installed system. Their `lightdm.conf` won't get overwritten to boot them into the installer session instead as `casper` isn't there to do the config.

`casper` will automatically detect what display manager is in use and knows how to configure it to automatically log in, so this should be a bit more robust and portable and is consistent with what Pop are doing downstream.

This is not yet tested, but I'm in the process of setting up nightly builds for a distinst based .iso too, so it should be easier to start getting this repo up to scratch soon.