### PR TITLE
deb-packaging: Don't install policy

### DIFF
--- a/debian/io.elementary.installer.install
+++ b/debian/io.elementary.installer.install
@@ -1,4 +1,3 @@
 usr/bin
 usr/share/applications
 usr/share/locale
-usr/share/polkit-1


### PR DESCRIPTION
This should be merged with #407 to prevent package build failures about the policy not existing anymore.