### PR TITLE
AbstractInstallerView: make constructor protected

### DIFF
--- a/src/Views/AbstractInstallerView.vala
+++ b/src/Views/AbstractInstallerView.vala
@@ -25,7 +25,7 @@ public abstract class AbstractInstallerView : Gtk.Grid {
     protected Gtk.Grid content_area;
     protected Gtk.ButtonBox action_area;
 
-    public AbstractInstallerView (bool cancellable = false) {
+    protected AbstractInstallerView (bool cancellable = false) {
         Object (
             cancellable: cancellable,
             row_spacing: 24


### PR DESCRIPTION
In our new version of vala, abstract classes can't have public constructors anymore.