### PR TITLE
Use --builtin for installer session

### DIFF
--- a/data/installer.desktop
+++ b/data/installer.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Installer
 Comment=This session provides elementary experience
-Exec=gnome-session --session=installer
+Exec=gnome-session --builtin --session=installer
 DesktopNames=Installer
 Type=Application


### PR DESCRIPTION
Makes the installer session work under the new version of `gnome-session` without setting up any systemd stuff yet. This will prevent the installer session from running on anything older than GNOME 3.34, but we can always take this bit out manually if we're testing on `bionic` for example.