### PR TITLE
Make compositor component name match desktop

### DIFF
--- a/data/installer.session
+++ b/data/installer.session
@@ -1,4 +1,4 @@
 [GNOME Session]
 Name=Installer
-RequiredComponents=io.elementary.greeter-compositor;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.XSettings;io.elementary.installer;
+RequiredComponents=io.elementary.installer.compositor;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.XSettings;io.elementary.installer;
 DesktopName=Installer


### PR DESCRIPTION
The installer package installs the desktop file for the greeter compositor (since it doesn't have one), and it gets renamed to `io.elementary.installer.compositor.desktop` , the component name in `RequiredComponents` has to match.

I think this is the cause of the installer session crashing.