### PR TITLE
Autostart installer with pkexec

### DIFF
--- a/data/autostart.desktop
+++ b/data/autostart.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Installer
-Exec=io.elementary.installer
+Exec=sh -c "pkexec env XDG_SEAT_PATH\=\$XDG_SEAT_PATH DISPLAY\=\$DISPLAY XAUTHORITY\=\$XAUTHORITY io.elementary.installer"
 Terminal=false
 Type=Application
 X-GNOME-Autostart-Notify=false


### PR DESCRIPTION
Fixes the issue where we weren't seeing any disks to install to.

When we created an autostart desktop, we didn't copy the `Exec` line from the actual working desktop file.