### PR TITLE
Honor XKB_CONFIG_ROOT environment variable, don't hardcode

### DIFF
--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -2,4 +2,5 @@ namespace Build {
     public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
     public const string LANG_LIST = "@LANG_LIST@";
     public const string PREFERRED_LANG_LIST = "@PREFERRED_LANG_LIST@";
+    public const string XKB_BASE = "@XKB_BASE@";
 }

--- a/src/Helpers/KeyboardLayoutHelper.vala
+++ b/src/Helpers/KeyboardLayoutHelper.vala
@@ -17,15 +17,26 @@
  */
 
 namespace KeyboardLayoutHelper {
+    public const string XKB_RULES_FILE = "base.xml";
+
     public struct Layout {
         public string name;
         public string description;
         public Gee.HashMap<string, string> variants;
     }
 
+    public string get_xml_rules_file_path () {
+        unowned string? base_path = GLib.Environment.get_variable ("XKB_CONFIG_ROOT");
+        if (base_path == null) {
+            base_path = Build.XKB_BASE;
+        }
+
+        return Path.build_filename (base_path, "rules", XKB_RULES_FILE);
+    }
+
     public static Gee.LinkedList<Layout?> get_layouts () {
         var layouts = new Gee.LinkedList<Layout?> ();
-        unowned Xml.Doc* doc = Xml.Parser.read_file ("/usr/share/X11/xkb/rules/base.xml");
+        unowned Xml.Doc* doc = Xml.Parser.read_file (get_xml_rules_file_path ());
         Xml.Node* root = doc->get_root_element ();
         Xml.Node* layout_list_node = get_xml_node_by_name (root, "layoutList");
         if (layout_list_node == null) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,3 @@
-
 vala_files = [
     'Application.vala',
     'MainWindow.vala',
@@ -34,6 +33,11 @@ vala_files = [
 configuration_data = configuration_data()
 configuration_data.set('GETTEXT_PACKAGE', meson.project_name())
 configuration_data.set('LANG_LIST', get_option('supported_languages'))
+
+xkbconf = dependency('xkeyboard-config')
+xkb_base = xkbconf.get_pkgconfig_variable('xkb_base')
+configuration_data.set('XKB_BASE', xkb_base)
+
 configuration_data.set('PREFERRED_LANG_LIST', get_option('preferred_languages'))
 
 config_file = configure_file(


### PR DESCRIPTION
PR on behalf of mutual interest from mercode OS and NixOS.
This has been a problem for us in NixOS for gnome-desktop [0] and other projects.
See aforementioned issue for more details.

cc @mkg20001

[0]: https://gitlab.gnome.org/GNOME/gnome-desktop/issues/130