### PR TITLE
Set XDG_CURRENT_DESKTOP to Pantheon

### DIFF
--- a/data/installer.session
+++ b/data/installer.session
@@ -2,3 +2,4 @@
 Name=Installer
 RequiredComponents=io.elementary.installer.compositor;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.XSettings;io.elementary.installer;
 DesktopName=Installer
+DesktopNames=Pantheon


### PR DESCRIPTION
I haven't tested this but I believe it will work in conjunction with https://github.com/elementary/default-settings/pull/186/ to ensure the installer session presents itself with the correct XDG_CURRENT_DESKTOP name to pick up the correct GSettings overrides.