### PR TITLE
CheckView: Bump minimum free space to 15GB

### DIFF
--- a/src/Views/CheckView.vala
+++ b/src/Views/CheckView.vala
@@ -22,7 +22,7 @@ public class Installer.CheckView : AbstractInstallerView {
     // We have to do it step by step because the vala compiler has overflows with big numbers.
     public const uint64 ONE_GB = 1000 * 1000 * 1000;
     // Minimum 5 GB
-    public const uint64 MINIMUM_SPACE = 5 * ONE_GB;
+    public const uint64 MINIMUM_SPACE = 15 * ONE_GB;
     // Minimum 1.2 GHz
     public const int MINIMUM_FREQUENCY = 1200 * 1000;
     // Minimum 1GB

--- a/src/Views/CheckView.vala
+++ b/src/Views/CheckView.vala
@@ -21,7 +21,7 @@
 public class Installer.CheckView : AbstractInstallerView {
     // We have to do it step by step because the vala compiler has overflows with big numbers.
     public const uint64 ONE_GB = 1000 * 1000 * 1000;
-    // Minimum 5 GB
+    // Minimum 15 GB
     public const uint64 MINIMUM_SPACE = 15 * ONE_GB;
     // Minimum 1.2 GHz
     public const int MINIMUM_FREQUENCY = 1200 * 1000;


### PR DESCRIPTION
I've just been helping diagnose some install failures on a daily iso from November and it turned out to be an issue with installing into a VM with a 10GiB virtual hard disk. It resulted in a fairly useless "unsquashfs failed" error that didn't indicate it was an out of space issue at all (which is probably a separate issue for distinst).

Once we bumped up the size of the disk image, the final installed size of the system was only 7.7GB, so would have fitted in the 10GiB disk image but there obviously needs to be a bit of a buffer to extract and then clean up afterwards.

We now know that even 10GiB is not enough for the 6.0 daily install to succeed, so lets bump this up to 15GB to at least give people a warning that the install might fail if they have less than that.