### PR TITLE
Split into GUI and Daemon

### DIFF
--- a/common/DBusStructures.vala
+++ b/common/DBusStructures.vala
@@ -58,12 +58,12 @@ public enum InstallerDaemon.MountFlags {
 }
 
 public struct InstallerDaemon.Mount {
-    public string partition_path;
-    public string parent_disk;
-    public string mount_point;
-    public uint64 sectors;
-    public Distinst.FileSystem filesystem;
-    public MountFlags flags;
+    string partition_path;
+    string parent_disk;
+    string mount_point;
+    uint64 sectors;
+    Distinst.FileSystem filesystem;
+    MountFlags flags;
 
     public bool is_valid_boot_mount () {
         return filesystem == Distinst.FileSystem.FAT16
@@ -86,7 +86,7 @@ public struct InstallerDaemon.Mount {
 }
 
 public struct InstallerDaemon.LuksCredentials {
-    public string device;
-    public string pv;
-    public string password;
+    string device;
+    string pv;
+    string password;
 }

--- a/common/DBusStructures.vala
+++ b/common/DBusStructures.vala
@@ -34,5 +34,40 @@ public struct InstallerDaemon.InstallConfig {
 }
 
 public struct InstallerDaemon.PartitionConfig {
-    string placeholder;
+    Mount[] mounts;
+}
+
+[Flags]
+public enum InstallerDaemon.MountFlags {
+    FORMAT = 1,
+    LVM = 2,
+    LVM_ON_LUKS = 4
+}
+
+public struct InstallerDaemon.Mount {
+    public string partition_path;
+    public string parent_disk;
+    public string mount_point;
+    public uint64 sectors;
+    public Distinst.FileSystem filesystem;
+    public MountFlags flags;
+
+    public bool is_valid_boot_mount () {
+        return filesystem == Distinst.FileSystem.FAT16
+            || filesystem == Distinst.FileSystem.FAT32;
+    }
+
+    public bool is_valid_root_mount () {
+        return filesystem != Distinst.FileSystem.FAT16
+            && filesystem != Distinst.FileSystem.FAT32
+            && filesystem != Distinst.FileSystem.NTFS;
+    }
+
+    public bool is_lvm () {
+        return MountFlags.LVM in flags;
+    }
+
+    public bool should_format () {
+        return MountFlags.FORMAT in flags;
+    }
 }

--- a/common/DBusStructures.vala
+++ b/common/DBusStructures.vala
@@ -24,3 +24,15 @@ public struct InstallerDaemon.Partition {
     Distinst.PartitionUsage sectors_used;
     string? current_lvm_volume_group;
 }
+
+public struct InstallerDaemon.InstallConfig {
+    string hostname;
+    string keyboard_layout;
+    string keyboard_variant;
+    string lang;
+    uint8 flags;
+}
+
+public struct InstallerDaemon.PartitionConfig {
+    string placeholder;
+}

--- a/common/DBusStructures.vala
+++ b/common/DBusStructures.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 elementary, Inc.
+ * Copyright 2021 elementary, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/common/DBusStructures.vala
+++ b/common/DBusStructures.vala
@@ -1,0 +1,28 @@
+public struct InstallerDaemon.DiskInfo {
+    Disk[] physical_disks;
+    Disk[] logical_disks;
+}
+
+public struct InstallerDaemon.Disk {
+    string model;
+    string serial;
+    string device_path;
+    uint64 sectors;
+    uint64 sector_size;
+    bool rotational;
+    bool removable;
+
+    Partition[] partitions;
+}
+
+public struct InstallerDaemon.Partition {
+    int number;
+    string device_path;
+
+    Distinst.FileSystem filesystem;
+
+    uint64 start_sector;
+    uint64 end_sector;
+    Distinst.PartitionUsage sectors_used;
+    string? current_lvm_volume_group;
+}

--- a/common/DBusStructures.vala
+++ b/common/DBusStructures.vala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2021 elementary, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 public struct InstallerDaemon.DiskInfo {
     Disk[] physical_disks;
     Disk[] logical_disks;

--- a/common/DBusStructures.vala
+++ b/common/DBusStructures.vala
@@ -4,8 +4,7 @@ public struct InstallerDaemon.DiskInfo {
 }
 
 public struct InstallerDaemon.Disk {
-    string model;
-    string serial;
+    string name;
     string device_path;
     uint64 sectors;
     uint64 sector_size;
@@ -16,7 +15,6 @@ public struct InstallerDaemon.Disk {
 }
 
 public struct InstallerDaemon.Partition {
-    int number;
     string device_path;
 
     Distinst.FileSystem filesystem;

--- a/common/DBusStructures.vala
+++ b/common/DBusStructures.vala
@@ -33,10 +33,6 @@ public struct InstallerDaemon.InstallConfig {
     uint8 flags;
 }
 
-public struct InstallerDaemon.PartitionConfig {
-    Mount[] mounts;
-}
-
 [Flags]
 public enum InstallerDaemon.MountFlags {
     FORMAT = 1,
@@ -70,4 +66,10 @@ public struct InstallerDaemon.Mount {
     public bool should_format () {
         return MountFlags.FORMAT in flags;
     }
+}
+
+public struct InstallerDaemon.LuksCredentials {
+    public string device;
+    public string pv;
+    public string password;
 }

--- a/common/meson.build
+++ b/common/meson.build
@@ -1,0 +1,3 @@
+common_files = files(
+    'DBusStructures.vala',
+)

--- a/daemon/Application.vala
+++ b/daemon/Application.vala
@@ -1,0 +1,174 @@
+private static GLib.MainLoop loop;
+
+[DBus (name = "io.elementary.InstallerDaemon")]
+public class InstallerDaemon.Application : GLib.Object {
+    public signal void on_log_message (string message);
+    public signal void on_status (Distinst.Status status);
+    public signal void on_error (Distinst.Error error);
+
+    private Distinst.Disks disks;
+
+    public void install (Distinst.Config config) {
+        var installer = new Distinst.Installer ();
+        installer.on_error ((error) => on_error (error));
+        installer.on_status ((status) => on_status (status));
+    }
+
+    public DiskInfo get_disks (bool get_partitions = false) throws GLib.Error {
+        DiskInfo result = DiskInfo ();
+
+        Disk[] physical_disks = {};
+        Disk[] logical_disks = {};
+
+        disks = Distinst.Disks.probe ();
+
+        if (get_partitions) {
+            disks.initialize_volume_groups ();
+        }
+
+        foreach (unowned Distinst.Disk disk in disks.list ()) {
+            // Skip root disk or live disk
+            if (disk.contains_mount ("/", disks) || disk.contains_mount ("/cdrom", disks)) {
+                continue;
+            }
+
+            Partition[] partitions = {};
+
+            if (get_partitions) {
+                foreach (unowned Distinst.Partition part in disk.list_partitions ()) {
+                    string lvm_vg = (part.get_file_system () == Distinst.FileSystem.LVM)
+                        ? string_from_utf8 (part.get_current_lvm_volume_group ())
+                        : "";
+
+                    partitions += Partition () {
+                        number = part.get_number (),
+                        device_path = string_from_utf8 (part.get_device_path ()),
+                        filesystem = part.get_file_system (),
+                        start_sector = part.get_start_sector (),
+                        end_sector = part.get_end_sector (),
+                        sectors_used = part.sectors_used (disk.get_sector_size ()),
+                        current_lvm_volume_group = lvm_vg
+                    };
+                }
+            }
+
+            physical_disks += Disk () {
+                model = string_from_utf8 (disk.get_model ()),
+                serial = string_from_utf8 (disk.get_serial ()),
+                device_path = string_from_utf8 (disk.get_device_path ()),
+                sectors = disk.get_sectors (),
+                sector_size = disk.get_sector_size (),
+                rotational = disk.is_rotational (),
+                removable = disk.is_removable (),
+                partitions = partitions
+            };
+        }
+
+        if (get_partitions) {
+            foreach (unowned Distinst.LvmDevice disk in disks.list_logical ()) {
+                Partition[] partitions = {};
+
+                foreach (unowned Distinst.Partition part in disk.list_partitions ()) {
+                    string lvm_vg = (part.get_file_system () == Distinst.FileSystem.LVM)
+                        ? string_from_utf8 (part.get_current_lvm_volume_group ())
+                        : "";
+
+                    partitions += Partition () {
+                        number = part.get_number (),
+                        device_path = string_from_utf8 (part.get_device_path ()),
+                        filesystem = part.get_file_system (),
+                        start_sector = part.get_start_sector (),
+                        end_sector = part.get_end_sector (),
+                        sectors_used = part.sectors_used (disk.get_sector_size ()),
+                        current_lvm_volume_group = lvm_vg
+                    };
+                }
+
+                logical_disks += Disk () {
+                    model = string_from_utf8 (disk.get_model ()),
+                    device_path = string_from_utf8 (disk.get_device_path ()),
+                    sectors = disk.get_sectors (),
+                    sector_size = disk.get_sector_size (),
+                    partitions = partitions
+                };
+            }
+        }
+
+        result.physical_disks = physical_disks;
+        result.logical_disks = logical_disks;
+        return result;
+    }
+
+    public int decrypt_partition (string path, string pv, string password) throws GLib.Error {
+        return disks.decrypt_partition (path, Distinst.LvmEncryption () {
+            physical_volume = pv,
+            password = password,
+            keydata = null
+        });
+    }
+
+    public Disk get_logical_device (string pv) throws GLib.Error {
+        unowned Distinst.LvmDevice disk = disks.get_logical_device (pv);
+
+        Partition[] partitions = {};
+
+        foreach (unowned Distinst.Partition part in disk.list_partitions ()) {
+            string lvm_vg = (part.get_file_system () == Distinst.FileSystem.LVM)
+                ? string_from_utf8 (part.get_current_lvm_volume_group ())
+                : "";
+
+            partitions += Partition () {
+                number = part.get_number (),
+                device_path = string_from_utf8 (part.get_device_path ()),
+                filesystem = part.get_file_system (),
+                start_sector = part.get_start_sector (),
+                end_sector = part.get_end_sector (),
+                sectors_used = part.sectors_used (disk.get_sector_size ()),
+                current_lvm_volume_group = lvm_vg
+            };
+        }
+
+        return Disk () {
+            model = string_from_utf8 (disk.get_model ()),
+            device_path = string_from_utf8 (disk.get_device_path ()),
+            sectors = disk.get_sectors (),
+            sector_size = disk.get_sector_size (),
+            partitions = partitions
+        };
+    }
+
+    private static string string_from_utf8 (uint8[] input) {
+        var builder = new GLib.StringBuilder.sized (input.length);
+        builder.append_len ((string) input, input.length);
+        return (owned) builder.str;
+    }
+}
+
+private void on_bus_acquired (GLib.DBusConnection connection, string name) {
+    try {
+        connection.register_object ("/io/elementary/InstallerDaemon", new InstallerDaemon.Application ());
+    } catch (GLib.Error e) {
+        critical ("Unable to register the object: %s", e.message);
+    }
+}
+
+public static int main (string[] args) {
+    loop = new GLib.MainLoop (null, false);
+
+    var owner_id = GLib.Bus.own_name (
+        GLib.BusType.SYSTEM,
+        "io.elementary.InstallerDaemon",
+        GLib.BusNameOwnerFlags.NONE,
+        on_bus_acquired,
+        () => { },
+        () => { loop.quit (); }
+    );
+
+    loop.run ();
+
+    GLib.Bus.unown_name (owner_id);
+
+    return 0;
+}
+
+

--- a/daemon/Application.vala
+++ b/daemon/Application.vala
@@ -2,11 +2,19 @@ private static GLib.MainLoop loop;
 
 [DBus (name = "io.elementary.InstallerDaemon")]
 public class InstallerDaemon.Application : GLib.Object {
-    public signal void on_log_message (string message);
+    public signal void on_log_message (Distinst.LogLevel level, string message);
     public signal void on_status (Distinst.Status status);
     public signal void on_error (Distinst.Error error);
 
     private Distinst.Disks disks;
+
+    construct {
+        Distinst.log ((level, message) => {
+            Idle.add (() => {
+                on_log_message (level, message);
+            });
+        });
+    }
 
     public Distinst.PartitionTable bootloader_detect () throws GLib.Error {
         return Distinst.bootloader_detect ();

--- a/daemon/Application.vala
+++ b/daemon/Application.vala
@@ -107,6 +107,9 @@ public class InstallerDaemon.Application : GLib.Object {
 
     public Disk get_logical_device (string pv) throws GLib.Error {
         unowned Distinst.LvmDevice disk = disks.get_logical_device (pv);
+        if (disk == null) {
+            throw new GLib.IOError.NOT_FOUND ("Couldn't find a logical device with that name");
+        }
 
         Partition[] partitions = {};
 

--- a/daemon/Application.vala
+++ b/daemon/Application.vala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2021 elementary, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 private static GLib.MainLoop loop;
 
 [DBus (name = "io.elementary.InstallerDaemon")]

--- a/daemon/Application.vala
+++ b/daemon/Application.vala
@@ -167,5 +167,3 @@ public static int main (string[] args) {
 
     return 0;
 }
-
-

--- a/daemon/Application.vala
+++ b/daemon/Application.vala
@@ -134,6 +134,250 @@ public class InstallerDaemon.Application : GLib.Object {
         };
     }
 
+    public void install_with_default_disk_layout (InstallConfig config, string disk, bool encrypt, string encryption_password) throws GLib.Error {
+        var installer = new Distinst.Installer ();
+        installer.on_error ((error) => on_error (error));
+        installer.on_status ((status) => on_status (status));
+
+        var distinst_config = Distinst.Config ();
+        distinst_config.flags = config.flags;
+        distinst_config.hostname = config.hostname;
+
+        var casper = casper_dir ();
+        distinst_config.remove = GLib.Path.build_filename (casper, "filesystem.manifest-remove");
+        distinst_config.squashfs = GLib.Path.build_filename (casper, "filesystem.squashfs");
+
+        debug ("language: %s\n", config.lang);
+        distinst_config.lang = config.lang;
+
+        distinst_config.keyboard_layout = config.keyboard_layout;
+        distinst_config.keyboard_model = null;
+        distinst_config.keyboard_variant = config.keyboard_variant == "" ? null : config.keyboard_variant;
+
+        var disks = new Distinst.Disks ();
+        if (!default_disk_configuration (disks, disk, encrypt ? encryption_password : null)) {
+            // TODO: Signal an error
+        }
+
+        new Thread<void*> (null, () => {
+            installer.install ((owned) disks, distinst_config);
+            return null;
+        });
+    }
+
+    public void install_with_custom_disk_layout (InstallConfig config, PartitionConfig disk_config) throws GLib.Error {
+
+    }
+
+    private string casper_dir () {
+        const string CDROM = "/cdrom";
+
+        try {
+            var cdrom_dir = File.new_for_path (CDROM);
+            var iter = cdrom_dir.enumerate_children (FileAttribute.STANDARD_NAME, 0);
+
+            FileInfo info;
+            while ((info = iter.next_file ()) != null) {
+                unowned string name = info.get_name ();
+                if (name.has_prefix ("casper")) {
+                    return GLib.Path.build_filename (CDROM, name);
+                }
+            }
+        } catch (GLib.Error e) {
+            critical ("failed to find casper dir automatically: %s\n", e.message);
+        }
+
+        return GLib.Path.build_filename (CDROM, "casper");
+    }
+
+    private bool default_disk_configuration (Distinst.Disks disks, string disk_path, string? encryption_password) {
+        var encrypted_vg = Distinst.generate_unique_id ("cryptdata");
+        var root_vg = Distinst.generate_unique_id ("data");
+        if (encrypted_vg == null || root_vg == null) {
+            critical ("unable to generate unique volume group IDs\n");
+            return false;
+        }
+
+        Distinst.LvmEncryption? encryption;
+        if (encryption_password != null) {
+            debug ("encrypting");
+            encryption = Distinst.LvmEncryption () {
+                physical_volume = encrypted_vg,
+                password = encryption_password,
+                keydata = null
+            };
+        } else {
+            debug ("not encrypting");
+            encryption = null;
+        }
+
+        debug ("disk: %s\n", disk_path);
+        var disk = new Distinst.Disk (disk_path);
+        if (disk == null) {
+            critical ("could not find %s", disk_path);
+            return false;
+        }
+
+        var bootloader = Distinst.bootloader_detect ();
+
+        var start_sector = Distinst.Sector () {
+            flag = Distinst.SectorKind.START,
+            value = 0
+        };
+
+        // 256 MiB is the minimum distinst ESP partition size, so this is 256 MiB in MB plus a bit
+        // extra for safety
+        var efi_sector = Distinst.Sector () {
+            flag = Distinst.SectorKind.MEGABYTE,
+            value = 278
+        };
+
+        // 512MB /boot partition that's created if we're doing encryption
+        var boot_sector = Distinst.Sector () {
+            flag = Distinst.SectorKind.MEGABYTE,
+            value = efi_sector.value + 512
+        };
+
+        // 4GB swap partition at the end
+        var swap_sector = Distinst.Sector () {
+            flag = Distinst.SectorKind.MEGABYTE_FROM_END,
+            value = 4096
+        };
+
+        var end_sector = Distinst.Sector () {
+            flag = Distinst.SectorKind.END,
+            value = 0
+        };
+
+        // Prepares a new partition table.
+        int result = disk.mklabel (bootloader);
+
+        if (result != 0) {
+            critical ("unable to write partition table to %s", disk_path);
+            return false;
+        }
+
+        var start = disk.get_sector (ref start_sector);
+        var end = disk.get_sector (ref boot_sector);
+
+        switch (bootloader) {
+            case Distinst.PartitionTable.MSDOS:
+                // This is used to ensure LVM installs will work with BIOS
+                result = disk.add_partition (
+                    new Distinst.PartitionBuilder (start, end, Distinst.FileSystem.EXT4)
+                        .partition_type (Distinst.PartitionType.PRIMARY)
+                        .flag (Distinst.PartitionFlag.BOOT)
+                        .mount ("/boot")
+                );
+
+                if (result != 0) {
+                    critical ("unable to add boot partition to %s", disk_path);
+                    return false;
+                }
+
+                break;
+            case Distinst.PartitionTable.GPT:
+                end = disk.get_sector (ref efi_sector);
+
+                // A FAT32 partition is required for EFI installs
+                result = disk.add_partition (
+                    new Distinst.PartitionBuilder (start, end, Distinst.FileSystem.FAT32)
+                        .partition_type (Distinst.PartitionType.PRIMARY)
+                        .flag (Distinst.PartitionFlag.ESP)
+                        .mount ("/boot/efi")
+                );
+
+                if (result != 0) {
+                    critical ("unable to add EFI partition to %s", disk_path);
+                    return false;
+                }
+
+                // If we're encrypting, we need an unencrypted partition to store kernels and initramfs images
+                if (encryption != null) {
+                    start = disk.get_sector (ref efi_sector);
+                    end = disk.get_sector (ref boot_sector);
+
+                    result = disk.add_partition (
+                        new Distinst.PartitionBuilder (start, end, Distinst.FileSystem.EXT4)
+                            .partition_type (Distinst.PartitionType.PRIMARY)
+                            .mount ("/boot")
+                    );
+
+                    if (result != 0) {
+                        critical ("unable to add /boot partition to %s", disk_path);
+                        return false;
+                    }
+                }
+
+                break;
+        }
+
+        // Start the LVM from the end of the /boot partition if we have encryption enabled
+        if (encryption != null) {
+            start = disk.get_sector (ref boot_sector);
+        } else {
+            start = disk.get_sector (ref efi_sector);
+        }
+
+        end = disk.get_sector (ref end_sector);
+
+        result = disk.add_partition (
+            new Distinst.PartitionBuilder (start, end, Distinst.FileSystem.LVM)
+                .partition_type (Distinst.PartitionType.PRIMARY)
+                .logical_volume (root_vg, encryption)
+        );
+
+        if (result != 0) {
+            critical ("unable to add lvm partition to %s", disk_path);
+            return false;
+        }
+
+        disks.push ((owned) disk);
+
+        result = disks.initialize_volume_groups ();
+
+        if (result != 0) {
+            critical ("unable to initialize volume groups on %s", disk_path);
+            return false;
+        }
+
+        unowned Distinst.LvmDevice lvm_device = disks.get_logical_device (root_vg);
+
+        if (lvm_device == null) {
+            critical ("unable to find '%s' volume group on %s", root_vg, disk_path);
+            return false;
+        }
+
+        start = lvm_device.get_sector (ref start_sector);
+        end = lvm_device.get_sector (ref swap_sector);
+
+        result = lvm_device.add_partition (
+            new Distinst.PartitionBuilder (start, end, Distinst.FileSystem.EXT4)
+                .name ("root")
+                .mount ("/")
+        );
+
+        if (result != 0) {
+            critical ("unable to add / partition to lvm on %s", disk_path);
+            return false;
+        }
+
+        start = lvm_device.get_sector (ref swap_sector);
+        end = lvm_device.get_sector (ref end_sector);
+
+        result = lvm_device.add_partition (
+            new Distinst.PartitionBuilder (start, end, Distinst.FileSystem.SWAP)
+                .name ("swap")
+        );
+
+        if (result != 0) {
+            critical ("unable to add swap partition to lvm on %s", disk_path);
+            return false;
+        }
+
+        return true;
+    }
+
     private static string string_from_utf8 (uint8[] input) {
         var builder = new GLib.StringBuilder.sized (input.length);
         builder.append_len ((string) input, input.length);

--- a/daemon/Daemon.vala
+++ b/daemon/Daemon.vala
@@ -18,7 +18,7 @@
 private static GLib.MainLoop loop;
 
 [DBus (name = "io.elementary.InstallerDaemon")]
-public class InstallerDaemon.Application : GLib.Object {
+public class InstallerDaemon.Daemon : GLib.Object {
     public signal void on_log_message (Distinst.LogLevel level, string message);
     public signal void on_status (Distinst.Status status);
     public signal void on_error (Distinst.Error error);
@@ -491,7 +491,7 @@ public class InstallerDaemon.Application : GLib.Object {
 
 private void on_bus_acquired (GLib.DBusConnection connection, string name) {
     try {
-        connection.register_object ("/io/elementary/InstallerDaemon", new InstallerDaemon.Application ());
+        connection.register_object ("/io/elementary/InstallerDaemon", new InstallerDaemon.Daemon ());
     } catch (GLib.Error e) {
         critical ("Unable to register the object: %s", e.message);
     }

--- a/daemon/Daemon.vala
+++ b/daemon/Daemon.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 elementary, Inc.
+ * Copyright 2021 elementary, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/daemon/io.elementary.InstallerDaemon.conf
+++ b/daemon/io.elementary.InstallerDaemon.conf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE busconfig PUBLIC
+  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <!-- Only root can own the service -->
+  <policy user="root">
+    <allow own="io.elementary.InstallerDaemon"/>
+  </policy>
+
+  <policy context="default">
+    <allow send_destination="io.elementary.InstallerDaemon"/>
+    <allow send_destination="io.elementary.InstallerDaemon" send_interface="org.freedesktop.DBus.Properties"/>
+    <allow send_destination="io.elementary.InstallerDaemon" send_interface="org.freedesktop.DBus.Introspectable"/>
+  </policy>
+</busconfig>

--- a/daemon/io.elementary.InstallerDaemon.service
+++ b/daemon/io.elementary.InstallerDaemon.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=elementary Installer Backend
+
+[Service]
+Type=dbus
+Restart=always
+BusName=io.elementary.InstallerDaemon
+ExecStart=io.elementary.installer-daemon
+
+[Install]
+WantedBy=multi-user.target

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -1,6 +1,6 @@
 vala_files = [
     'Daemon.vala',
-    join_paths(meson.source_root(), 'common', 'DBusStructures.vala'),
+    common_files
 ]
 
 daemon_dependencies = [

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -1,0 +1,25 @@
+vala_files = [
+    'Application.vala',
+    join_paths(meson.source_root(), 'common', 'DBusStructures.vala'),
+]
+
+daemon_dependencies = [
+    distinst_dep,
+    gee_dep,
+    glib_dep,
+    gio_dep,
+    gobject_dep,
+]
+
+systemdunitdir = systemd_dep.get_pkgconfig_variable('systemdsystemunitdir')
+
+install_data(
+    'io.elementary.InstallerDaemon.service',
+    install_dir: systemdunitdir
+)
+
+install_data('io.elementary.InstallerDaemon.conf', install_dir : get_option('datadir') / 'dbus-1' / 'system.d')
+
+executable(meson.project_name() + '-daemon', vala_files,
+           dependencies : daemon_dependencies,
+           install: true)

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -1,5 +1,5 @@
 vala_files = [
-    'Application.vala',
+    'Daemon.vala',
     join_paths(meson.source_root(), 'common', 'DBusStructures.vala'),
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,7 @@ asresources = gnome.compile_resources(
 )
 
 subdir('po')
+subdir('common')
 subdir('daemon')
 subdir('src')
 subdir('data')

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ glib_dep = dependency('glib-2.0')
 gobject_dep = dependency('gobject-2.0')
 gtk_dep = dependency('gtk+-3.0')
 gee_dep = dependency('gee-0.8')
+gio_dep = dependency('gio-2.0')
 granite_dep = dependency('granite', version: '>=0.5')
 handy_dep = dependency('libhandy-1', version: '>=0.90.0')
 json_glib_dep = dependency('json-glib-1.0')
@@ -19,21 +20,7 @@ xml2_dep = dependency('libxml-2.0')
 gnome_keyboard_dep = dependency('libgnomekbd')
 gnome_keyboard_ui_dep = meson.get_compiler('c').find_library('gnomekbdui')
 pwquality_dep = dependency('pwquality')
-
-dependencies = [
-    distinst_dep,
-    gee_dep,
-    glib_dep,
-    gnome_keyboard_dep,
-    gnome_keyboard_ui_dep,
-    gobject_dep,
-    granite_dep,
-    gtk_dep,
-    handy_dep,
-    json_glib_dep,
-    pwquality_dep,
-    xml2_dep
-]
+systemd_dep = dependency('systemd')
 
 asresources = gnome.compile_resources(
     'as-resources', 'data/' + meson.project_name() + '.gresource.xml',
@@ -42,5 +29,6 @@ asresources = gnome.compile_resources(
 )
 
 subdir('po')
+subdir('daemon')
 subdir('src')
 subdir('data')

--- a/src/Helpers/InstallerDaemon.vala
+++ b/src/Helpers/InstallerDaemon.vala
@@ -13,6 +13,7 @@ public class Installer.Daemon {
         public async abstract int decrypt_partition (string path, string pv, string password) throws GLib.Error;
         public async abstract InstallerDaemon.Disk get_logical_device (string pv) throws GLib.Error;
         public async abstract void install_with_default_disk_layout (InstallerDaemon.InstallConfig config, string disk, bool encrypt, string encryption_password) throws GLib.Error;
+        public async abstract void install_with_custom_disk_layout (InstallerDaemon.InstallConfig config, InstallerDaemon.Mount[] disk_config, InstallerDaemon.LuksCredentials[] luks) throws GLib.Error;
     }
 
     public signal void on_error (Distinst.Error error);
@@ -46,6 +47,10 @@ public class Installer.Daemon {
 
     public async void install_with_default_disk_layout (InstallerDaemon.InstallConfig config, string disk, bool encrypt, string encryption_password) throws GLib.Error {
         yield daemon.install_with_default_disk_layout (config, disk, encrypt, encryption_password);
+    }
+
+    public async void install_with_custom_disk_layout (InstallerDaemon.InstallConfig config, InstallerDaemon.Mount[] disk_config, InstallerDaemon.LuksCredentials[] luks) throws GLib.Error {
+        yield daemon.install_with_custom_disk_layout (config, disk_config, luks);
     }
 
     private static Daemon? _instance = null;

--- a/src/Helpers/InstallerDaemon.vala
+++ b/src/Helpers/InstallerDaemon.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 elementary, Inc.
+ * Copyright 2021 elementary, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/Helpers/InstallerDaemon.vala
+++ b/src/Helpers/InstallerDaemon.vala
@@ -6,6 +6,7 @@ public class Installer.Daemon {
     private interface InstallerInterface : GLib.DBusProxy {
         public signal void on_error (Distinst.Error error);
         public signal void on_status (Distinst.Status status);
+        public signal void on_log_message (Distinst.LogLevel level, string message);
 
         public abstract Distinst.PartitionTable bootloader_detect () throws GLib.Error;
 
@@ -18,6 +19,7 @@ public class Installer.Daemon {
 
     public signal void on_error (Distinst.Error error);
     public signal void on_status (Distinst.Status status);
+    public signal void on_log_message (Distinst.LogLevel level, string message);
 
     private InstallerInterface daemon;
 
@@ -27,6 +29,7 @@ public class Installer.Daemon {
 
         daemon.on_error.connect ((error) => on_error (error));
         daemon.on_status.connect ((status) => on_status (status));
+        daemon.on_log_message.connect ((level, message) => on_log_message (level, message));
     }
 
     public Distinst.PartitionTable bootloader_detect () throws GLib.Error {

--- a/src/Helpers/InstallerDaemon.vala
+++ b/src/Helpers/InstallerDaemon.vala
@@ -4,6 +4,7 @@ public class Installer.Daemon {
 
     [DBus (name = "io.elementary.InstallerDaemon")]
     private interface InstallerInterface : GLib.DBusProxy {
+        public abstract Distinst.PartitionTable bootloader_detect () throws GLib.Error;
         public async abstract InstallerDaemon.DiskInfo get_disks (bool get_partitions = false) throws GLib.Error;
         public async abstract int decrypt_partition (string path, string pv, string password) throws GLib.Error;
         public async abstract InstallerDaemon.Disk get_logical_device (string pv) throws GLib.Error;
@@ -14,6 +15,10 @@ public class Installer.Daemon {
     private Daemon () {
         daemon = Bus.get_proxy_sync (BusType.SYSTEM, "io.elementary.InstallerDaemon", "/io/elementary/InstallerDaemon");
         daemon.g_default_timeout = DBUS_TIMEOUT_MSEC;
+    }
+
+    public Distinst.PartitionTable bootloader_detect () throws GLib.Error {
+        return daemon.bootloader_detect ();
     }
 
     public async InstallerDaemon.DiskInfo get_disks (bool get_partitions = false) throws GLib.Error {

--- a/src/Helpers/InstallerDaemon.vala
+++ b/src/Helpers/InstallerDaemon.vala
@@ -1,4 +1,7 @@
 public class Installer.Daemon {
+    // Wait up to 60 seconds for DBus calls to timeout. Some of the Distinst disk probe operations seem to take around 30 seconds
+    private const int DBUS_TIMEOUT_MSEC = 60 * 1000;
+
     [DBus (name = "io.elementary.InstallerDaemon")]
     private interface InstallerInterface : GLib.DBusProxy {
         public async abstract InstallerDaemon.DiskInfo get_disks (bool get_partitions = false) throws GLib.Error;
@@ -10,6 +13,7 @@ public class Installer.Daemon {
 
     private Daemon () {
         daemon = Bus.get_proxy_sync (BusType.SYSTEM, "io.elementary.InstallerDaemon", "/io/elementary/InstallerDaemon");
+        daemon.g_default_timeout = DBUS_TIMEOUT_MSEC;
     }
 
     public async InstallerDaemon.DiskInfo get_disks (bool get_partitions = false) throws GLib.Error {

--- a/src/Helpers/InstallerDaemon.vala
+++ b/src/Helpers/InstallerDaemon.vala
@@ -1,0 +1,36 @@
+public class Installer.Daemon {
+    [DBus (name = "io.elementary.InstallerDaemon")]
+    private interface InstallerInterface : GLib.DBusProxy {
+        public async abstract InstallerDaemon.DiskInfo get_disks (bool get_partitions = false) throws GLib.Error;
+        public async abstract int decrypt_partition (string path, string pv, string password) throws GLib.Error;
+        public async abstract InstallerDaemon.Disk get_logical_device (string pv) throws GLib.Error;
+    }
+
+    private InstallerInterface daemon;
+
+    private Daemon () {
+        daemon = Bus.get_proxy_sync (BusType.SYSTEM, "io.elementary.InstallerDaemon", "/io/elementary/InstallerDaemon");
+    }
+
+    public async InstallerDaemon.DiskInfo get_disks (bool get_partitions = false) throws GLib.Error {
+        return yield daemon.get_disks (get_partitions);
+    }
+
+    public async int decrypt_partition (string path, string pv, string password) throws GLib.Error {
+        return yield daemon.decrypt_partition (path, pv, password);
+    }
+
+    public async InstallerDaemon.Disk get_logical_device (string pv) throws GLib.Error {
+        return yield daemon.get_logical_device (pv);
+    }
+
+    private static Daemon? _instance = null;
+    public static unowned Daemon get_default () {
+        if (_instance != null) {
+            return _instance;
+        }
+
+        _instance = new Daemon ();
+        return _instance;
+    }
+}

--- a/src/Helpers/LogHelper.vala
+++ b/src/Helpers/LogHelper.vala
@@ -48,21 +48,13 @@ public class LogHelper : GLib.Object {
     construct {
         buffer = new Gtk.TextBuffer (null);
         buffer.text = "";
-        if (Distinst.log (log_func) != 0) {
-            log_func (Distinst.LogLevel.ERROR, _("Unable to set the Distinst log callback"));
-        } else {
-            log_func (Distinst.LogLevel.INFO, _("Starting installation"));
-        }
     }
 
-    private void log_func (Distinst.LogLevel level, string message) {
+    public void log_func (Distinst.LogLevel level, string message) {
         stdout.printf ("log: %s: %s\n", level_name (level), message);
-        Idle.add (() => {
-            Gtk.TextIter end_iter;
-            buffer.get_end_iter (out end_iter);
-            string new_line = "\n" + level_name (level) + ": " + message;
-            buffer.insert (ref end_iter, new_line, new_line.length);
-            return GLib.Source.REMOVE;
-        });
+        Gtk.TextIter end_iter;
+        buffer.get_end_iter (out end_iter);
+        string new_line = "\n" + level_name (level) + ": " + message;
+        buffer.insert (ref end_iter, new_line, new_line.length);
     }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -32,7 +32,6 @@ public class Installer.MainWindow : Hdy.Window {
     private ErrorView error_view;
     private bool check_ignored = false;
 
-    private uint64 minimum_disk_size;
 
     public MainWindow () {
         Object (
@@ -56,8 +55,6 @@ public class Installer.MainWindow : Hdy.Window {
         stack.add (language_view);
 
         add (stack);
-
-        minimum_disk_size = Distinst.minimum_disk_size (5000000000);
 
         language_view.next_step.connect (() => load_keyboard_view ());
     }
@@ -109,7 +106,7 @@ public class Installer.MainWindow : Hdy.Window {
             check_view.destroy ();
         }
 
-        check_view = new Installer.CheckView (minimum_disk_size);
+        check_view = new Installer.CheckView ();
         stack.add (check_view);
 
         check_view.status_changed.connect ((met_requirements) => {
@@ -160,7 +157,7 @@ public class Installer.MainWindow : Hdy.Window {
         disk_view.previous_view = try_install_view;
         stack.add (disk_view);
         stack.visible_child = disk_view;
-        disk_view.load.begin (minimum_disk_size);
+        disk_view.load.begin (CheckView.MINIMUM_SPACE);
 
         disk_view.cancel.connect (() => {
             stack.visible_child = try_install_view;
@@ -174,7 +171,7 @@ public class Installer.MainWindow : Hdy.Window {
             partitioning_view.destroy ();
         }
 
-        partitioning_view = new PartitioningView (minimum_disk_size);
+        partitioning_view = new PartitioningView (CheckView.MINIMUM_SPACE);
         partitioning_view.previous_view = try_install_view;
         stack.add (partitioning_view);
         stack.visible_child = partitioning_view;

--- a/src/Objects/Configuration.vala
+++ b/src/Objects/Configuration.vala
@@ -35,5 +35,5 @@ public class Configuration : GLib.Object {
     public string? encryption_password { get; set; default = null; }
     public string disk { get; set; }
     public Gee.ArrayList<Installer.Mount>? mounts { get; set; default = null; }
-    public Gee.ArrayList<Installer.LuksCredentials>? luks { get; set; default = null; }
+    public Gee.ArrayList<InstallerDaemon.LuksCredentials?>? luks { get; set; default = null; }
 }

--- a/src/Objects/Mount.vala
+++ b/src/Objects/Mount.vala
@@ -24,18 +24,11 @@ public class Installer.Mount {
     public string mount_point;
     public uint64 sectors;
     public Distinst.FileSystem filesystem;
-    public Flags flags;
+    public InstallerDaemon.MountFlags flags;
     public PartitionMenu menu;
 
-    [Flags]
-    public enum Flags {
-        FORMAT = 1,
-        LVM = 2,
-        LVM_ON_LUKS = 4
-    }
-
     public Mount (string partition, string parent_disk, string mount,
-                  uint64 sectors, Flags flags, Distinst.FileSystem fs,
+                  uint64 sectors, InstallerDaemon.MountFlags flags, Distinst.FileSystem fs,
                   PartitionMenu menu) {
         filesystem = fs;
         mount_point = mount;
@@ -58,22 +51,10 @@ public class Installer.Mount {
     }
 
     public bool is_lvm () {
-        return Flags.LVM in flags;
+        return InstallerDaemon.MountFlags.LVM in flags;
     }
 
     public bool should_format () {
-        return Flags.FORMAT in flags;
-    }
-}
-
-public class Installer.LuksCredentials {
-    public string device;
-    public string pv;
-    public string password;
-
-    public LuksCredentials (string device, string pv, string password) {
-        this.device = device;
-        this.pv = pv;
-        this.password = password;
+        return InstallerDaemon.MountFlags.FORMAT in flags;
     }
 }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -19,30 +19,13 @@
  */
 
 namespace Utils {
-    public string string_from_utf8 (uint8[] input) {
-        var builder = new GLib.StringBuilder.sized (input.length);
-        builder.append_len ((string) input, input.length);
-        return (owned) builder.str;
-    }
-
-    private struct OsRelease {
-        public string pretty_name;
-
-        public static OsRelease new () {
-            return OsRelease () {
-                pretty_name = string_from_utf8 (Distinst.get_os_pretty_name ())
-            };
-        }
-    }
-
-    private static OsRelease? os_release;
-
+    private static string? pretty_name;
     private static string get_pretty_name () {
-        if (os_release == null) {
-            os_release = OsRelease.new ();
+        if (pretty_name == null) {
+            pretty_name = GLib.Environment.get_os_info (GLib.OsInfoKey.PRETTY_NAME);
         }
 
-        return os_release.pretty_name;
+        return pretty_name;
     }
 
     public static void shutdown () {

--- a/src/Views/CheckView.vala
+++ b/src/Views/CheckView.vala
@@ -97,7 +97,7 @@ public class Installer.CheckView : AbstractInstallerView {
 
         Daemon.get_default ().get_disks.begin (false, (obj, res) => {
             try {
-                disks = Daemon.get_default ().get_disks.end (res);
+                disks = ((Daemon)obj).get_disks.end (res);
             } catch (Error e) {
                 critical ("Unable to get disks list: %s", e.message);
             } finally {
@@ -117,7 +117,6 @@ public class Installer.CheckView : AbstractInstallerView {
                 return true;
             }
         }
-
         return false;
     }
 
@@ -162,7 +161,7 @@ public class Installer.CheckView : AbstractInstallerView {
             try {
                 upower = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.UPower", "/org/freedesktop/UPower", GLib.DBusProxyFlags.GET_INVALIDATED_PROPERTIES);
 
-                upower.g_properties_changed.connect ((changed, invalid) => {
+                (upower as DBusProxy).g_properties_changed.connect ((changed, invalid) => {
                     var _on_battery = changed.lookup_value ("OnBattery", GLib.VariantType.BOOLEAN);
                     if (_on_battery != null) {
                         status_changed (check_requirements ());
@@ -357,6 +356,6 @@ public class Installer.CheckView : AbstractInstallerView {
 }
 
 [DBus (name = "org.freedesktop.UPower")]
-public interface UPower : DBusProxy {
+public interface UPower : GLib.Object {
     public abstract bool on_battery { owned get; set; }
 }

--- a/src/Views/DiskView.vala
+++ b/src/Views/DiskView.vala
@@ -125,15 +125,8 @@ public class Installer.DiskView : AbstractInstallerView {
                 icon_name = "drive-harddisk-solidstate";
             }
 
-            string label;
-            if (disk.model.length == 0) {
-                label = disk.serial.replace ("_", " ");
-            } else {
-                label = disk.model;
-            }
-
             var disk_button = new DiskButton (
-                label,
+                disk.name,
                 icon_name,
                 disk.device_path,
                 size

--- a/src/Views/DiskView.vala
+++ b/src/Views/DiskView.vala
@@ -107,7 +107,15 @@ public class Installer.DiskView : AbstractInstallerView {
         DiskButton[] enabled_buttons = {};
         DiskButton[] disabled_buttons = {};
 
-        InstallerDaemon.DiskInfo disks = yield Daemon.get_default ().get_disks ();
+        InstallerDaemon.DiskInfo? disks;
+        try {
+            disks = yield Daemon.get_default ().get_disks ();
+        } catch (Error e) {
+            critical ("Unable to get disks list: %s", e.message);
+            load_stack.set_visible_child_name ("disk");
+            return;
+        }
+
         foreach (unowned InstallerDaemon.Disk disk in disks.physical_disks) {
             var size = disk.sectors * disk.sector_size;
 

--- a/src/Views/DiskView.vala
+++ b/src/Views/DiskView.vala
@@ -103,48 +103,39 @@ public class Installer.DiskView : AbstractInstallerView {
         show_all ();
     }
 
-    // If possible, open devices in a different thread so that the interface stays awake.
     public async void load (uint64 minimum_disk_size) {
         DiskButton[] enabled_buttons = {};
         DiskButton[] disabled_buttons = {};
 
-        Distinst.Disks disks = Distinst.Disks.probe ();
-        foreach (unowned Distinst.Disk disk in disks.list ()) {
-            // Skip root disk or live disk
-            if (disk.contains_mount ("/", disks) || disk.contains_mount ("/cdrom", disks)) {
-                continue;
-            }
-
-            var size = disk.get_sectors () * disk.get_sector_size ();
+        InstallerDaemon.DiskInfo disks = yield Daemon.get_default ().get_disks ();
+        foreach (unowned InstallerDaemon.Disk disk in disks.physical_disks) {
+            var size = disk.sectors * disk.sector_size;
 
             // Drives are identifiable by whether they are rotational and/or removable.
             string icon_name = null;
-            if (disk.is_removable ()) {
-                if (disk.is_rotational ()) {
+            if (disk.removable) {
+                if (disk.rotational) {
                     icon_name = "drive-harddisk-usb";
                 } else {
                     icon_name = "drive-removable-media-usb";
                 }
-            } else if (disk.is_rotational ()) {
+            } else if (disk.rotational) {
                 icon_name = "drive-harddisk-scsi";
             } else {
                 icon_name = "drive-harddisk-solidstate";
             }
 
             string label;
-            string model = Utils.string_from_utf8 (disk.get_model ());
-            if (model.length == 0) {
-                label = Utils.string_from_utf8 (disk.get_serial ()).replace ("_", " ");
+            if (disk.model.length == 0) {
+                label = disk.serial.replace ("_", " ");
             } else {
-                label = model;
+                label = disk.model;
             }
-
-            string path = Utils.string_from_utf8 (disk.get_device_path ());
 
             var disk_button = new DiskButton (
                 label,
                 icon_name,
-                path,
+                disk.device_path,
                 size
             );
 

--- a/src/Views/KeyboardLayoutView.vala
+++ b/src/Views/KeyboardLayoutView.vala
@@ -103,9 +103,6 @@ public class KeyboardLayoutView : AbstractInstallerView {
                     row.activate ();
                     return;
                 }
-
-                warning (configuration.keyboard_layout);
-                warning (configuration.keyboard_variant);
             } else {
                 warning ("next_button enabled when no keyboard selected");
                 next_button.sensitive = false;

--- a/src/Views/KeyboardLayoutView.vala
+++ b/src/Views/KeyboardLayoutView.vala
@@ -103,6 +103,9 @@ public class KeyboardLayoutView : AbstractInstallerView {
                     row.activate ();
                     return;
                 }
+
+                warning (configuration.keyboard_layout);
+                warning (configuration.keyboard_variant);
             } else {
                 warning ("next_button enabled when no keyboard selected");
                 next_button.sensitive = false;

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -155,7 +155,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
             var sector_size = disk.sector_size;
             var size = disk.sectors * sector_size;
 
-            string path = disk.device_path;
+            unowned string path = disk.device_path;
 
             var partitions = new Gee.ArrayList<PartitionBar> ();
             foreach (unowned InstallerDaemon.Partition part in disk.partitions) {
@@ -207,7 +207,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
         var sector_size = disk.sector_size;
         var size = disk.sectors * sector_size;
 
-        string path = disk.device_path;
+        unowned string path = disk.device_path;
 
         var partitions = new Gee.ArrayList<PartitionBar> ();
         foreach (unowned InstallerDaemon.Partition part in disk.partitions) {
@@ -260,7 +260,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
         luks.add (credentials);
         Daemon.get_default ().get_logical_device.begin (credentials.pv, (obj, res) => {
             try {
-                var disk = Daemon.get_default ().get_logical_device.end (res);
+                var disk = ((Daemon)obj).get_logical_device.end (res);
                 add_logical_disk (disk);
             } catch (Error e) {
                 critical ("Unable to get logical device: %s", e.message);

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -29,7 +29,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
     private string required_description;
 
     public Gee.ArrayList<Installer.Mount> mounts;
-    public Gee.ArrayList<LuksCredentials> luks;
+    public Gee.ArrayList<InstallerDaemon.LuksCredentials?> luks;
 
     public static uint64 minimum_disk_size;
 
@@ -48,7 +48,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
 
     construct {
         mounts = new Gee.ArrayList<Installer.Mount> ();
-        luks = new Gee.ArrayList<LuksCredentials> ();
+        luks = new Gee.ArrayList<InstallerDaemon.LuksCredentials?> ();
         margin = 12;
 
         var base_description = _("Select which partitions to use across all drives. <b>Selecting \"Format\" will erase ALL data on the selected partition.</b>");
@@ -248,7 +248,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
         next_button.sensitive = required in flags;
     }
 
-    private void on_partition_decrypted (LuksCredentials credentials) {
+    private void on_partition_decrypted (InstallerDaemon.LuksCredentials credentials) {
         luks.add (credentials);
         Daemon.get_default ().get_logical_device.begin (credentials.pv, (obj, res) => {
             var disk = Daemon.get_default ().get_logical_device.end (res);

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -53,7 +53,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
 
         var base_description = _("Select which partitions to use across all drives. <b>Selecting \"Format\" will erase ALL data on the selected partition.</b>");
 
-        var bootloader = Distinst.bootloader_detect ();
+        var bootloader = Daemon.get_default ().bootloader_detect ();
         switch (bootloader) {
             case Distinst.PartitionTable.MSDOS:
                 // Device is in BIOS mode, so we just require a root partition
@@ -217,7 +217,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
         uint8 flags = 0;
         uint8 required = Defined.ROOT;
 
-        var bootloader = Distinst.bootloader_detect ();
+        var bootloader = Daemon.get_default ().bootloader_detect ();
         switch (bootloader) {
             case Distinst.PartitionTable.MSDOS:
                 break;

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -91,9 +91,11 @@ public class ProgressView : AbstractInstallerView {
     }
 
     public void real_installation () {
+        unowned LogHelper log_helper = LogHelper.get_default ();
         unowned Installer.Daemon daemon = Installer.Daemon.get_default ();
         daemon.on_error.connect (installation_error_callback);
         daemon.on_status.connect (installation_status_callback);
+        daemon.on_log_message.connect (log_helper.log_func);
 
         var config = InstallerDaemon.InstallConfig ();
         config.flags = Distinst.MODIFY_BOOT_ORDER;

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -91,8 +91,9 @@ public class ProgressView : AbstractInstallerView {
     }
 
     public void real_installation () {
-        Installer.Daemon.get_default ().on_error.connect (installation_error_callback);
-        Installer.Daemon.get_default ().on_status.connect (installation_status_callback);
+        unowned Installer.Daemon daemon = Installer.Daemon.get_default ();
+        daemon.on_error.connect (installation_error_callback);
+        daemon.on_status.connect (installation_status_callback);
 
         var config = InstallerDaemon.InstallConfig ();
         config.flags = Distinst.MODIFY_BOOT_ORDER;
@@ -113,7 +114,12 @@ public class ProgressView : AbstractInstallerView {
         config.keyboard_variant = current_config.keyboard_variant ?? "";
 
         if (current_config.mounts == null) {
-            Installer.Daemon.get_default ().install_with_default_disk_layout (config, current_config.disk, current_config.encryption_password != null, current_config.encryption_password ?? "");
+            daemon.install_with_default_disk_layout.begin (
+                config,
+                current_config.disk,
+                current_config.encryption_password != null,
+                current_config.encryption_password ?? ""
+            );
         } else {
             InstallerDaemon.Mount[] mounts = {};
             foreach (Installer.Mount m in current_config.mounts) {
@@ -134,7 +140,7 @@ public class ProgressView : AbstractInstallerView {
                 }
             }
 
-            Installer.Daemon.get_default ().install_with_custom_disk_layout (config, mounts, creds);
+            daemon.install_with_custom_disk_layout.begin (config, mounts, creds);
         }
     }
 

--- a/src/Views/ProgressView.vala
+++ b/src/Views/ProgressView.vala
@@ -120,8 +120,15 @@ public class ProgressView : AbstractInstallerView {
                 config,
                 current_config.disk,
                 current_config.encryption_password != null,
-                current_config.encryption_password ?? ""
-            );
+                current_config.encryption_password ?? "",
+            (obj, res) => {
+                try {
+                    daemon.install_with_default_disk_layout.end (res);
+                } catch (Error e) {
+                    log_helper.log_func (Distinst.LogLevel.ERROR, e.message);
+                    on_error ();
+                }
+            });
         } else {
             InstallerDaemon.Mount[] mounts = {};
             foreach (Installer.Mount m in current_config.mounts) {
@@ -142,7 +149,14 @@ public class ProgressView : AbstractInstallerView {
                 }
             }
 
-            daemon.install_with_custom_disk_layout.begin (config, mounts, creds);
+            daemon.install_with_custom_disk_layout.begin (config, mounts, creds, (obj, res) => {
+                try {
+                    daemon.install_with_custom_disk_layout.end (res);
+                } catch (Error e) {
+                    log_helper.log_func (Distinst.LogLevel.ERROR, e.message);
+                    on_error ();
+                }
+            });
         }
     }
 

--- a/src/Widgets/DecryptMenu.vala
+++ b/src/Widgets/DecryptMenu.vala
@@ -28,7 +28,7 @@ public class Installer.DecryptMenu: Gtk.Popover {
 
     private string device_path;
 
-    public signal void decrypted (LuksCredentials creds);
+    public signal void decrypted (InstallerDaemon.LuksCredentials creds);
 
     public DecryptMenu (string device_path) {
         this.device_path = device_path;
@@ -130,7 +130,13 @@ public class Installer.DecryptMenu: Gtk.Popover {
         switch (result) {
             case 0:
                 set_decrypted (pv);
-                decrypted (new LuksCredentials (device_path, pv, password));
+                var creds = InstallerDaemon.LuksCredentials () {
+                    device = device_path,
+                    pv = pv,
+                    password = password
+                };
+
+                decrypted ((owned)creds);
                 break;
             case 1:
                 debug ("decrypt_partition result is 1");

--- a/src/Widgets/DecryptMenu.vala
+++ b/src/Widgets/DecryptMenu.vala
@@ -18,8 +18,6 @@
  * Authored by: Michael Aaron Murphy <michael@system76.com>
  */
 
-public delegate void DecryptFn (string path, string pv, string pass, Installer.DecryptMenu menu);
-
 public class Installer.DecryptMenu: Gtk.Popover {
     private Gtk.Stack stack;
 
@@ -28,15 +26,21 @@ public class Installer.DecryptMenu: Gtk.Popover {
     private Gtk.Entry pass_entry;
     private Gtk.Entry pv_entry;
 
-    public DecryptMenu (string device_path, DecryptFn decrypt) {
+    private string device_path;
+
+    public signal void decrypted (LuksCredentials creds);
+
+    public DecryptMenu (string device_path) {
+        this.device_path = device_path;
+
         stack = new Gtk.Stack ();
         stack.margin = 12;
-        create_decrypt_view (device_path, decrypt);
+        create_decrypt_view ();
         add (stack);
         stack.show_all ();
     }
 
-    private void create_decrypt_view (string device_path, DecryptFn decrypt) {
+    private void create_decrypt_view () {
         var image = new Gtk.Image.from_icon_name ("drive-harddisk", Gtk.IconSize.DIALOG);
         image.valign = Gtk.Align.START;
 
@@ -77,7 +81,7 @@ public class Installer.DecryptMenu: Gtk.Popover {
         pass_entry.changed.connect (() => set_sensitivity ());
         pass_entry.activate.connect (() => {
             if (entries_set ()) {
-                decrypt (device_path, pv_entry.get_text (), pass_entry.get_text (), this);
+                decrypt (pv_entry.get_text ());
             }
         });
 
@@ -90,7 +94,7 @@ public class Installer.DecryptMenu: Gtk.Popover {
         pv_entry.changed.connect (() => set_sensitivity ());
         pv_entry.activate.connect (() => {
             if (entries_set ()) {
-                decrypt (device_path, pv_entry.get_text (), pass_entry.get_text (), this);
+                decrypt (pv_entry.get_text ());
             }
         });
 
@@ -99,7 +103,7 @@ public class Installer.DecryptMenu: Gtk.Popover {
         decrypt_button.sensitive = false;
         decrypt_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
         decrypt_button.clicked.connect (() => {
-            decrypt (device_path, pv_entry.get_text (), pass_entry.get_text (), this);
+            decrypt (pv_entry.get_text ());
         });
 
         decrypt_view = new Gtk.Grid ();
@@ -116,6 +120,40 @@ public class Installer.DecryptMenu: Gtk.Popover {
         stack.add (decrypt_view);
         stack.visible_child = decrypt_view;
         pass_entry.grab_focus_without_selecting ();
+    }
+
+    private async void decrypt (string pv) {
+        string password = pass_entry.get_text ();
+
+        int result = yield Daemon.get_default ().decrypt_partition (device_path, pv_entry.get_text (), password);
+
+        switch (result) {
+            case 0:
+                set_decrypted (pv);
+                decrypted (new LuksCredentials (device_path, pv, password));
+                break;
+            case 1:
+                debug ("decrypt_partition result is 1");
+                break;
+            case 2:
+                debug ("decrypt: input was not valid UTF-8");
+                break;
+            case 3:
+                debug ("decrypt: either a password or keydata string must be supplied");
+                break;
+            case 4:
+                debug ("decrypt: unable to decrypt partition (possibly invalid password)");
+                break;
+            case 5:
+                debug ("decrypt: the decrypted partition does not have a LVM volume on it");
+                break;
+            case 6:
+                debug ("decrypt: unable to locate LUKS partition at %s", device_path);
+                break;
+            default:
+                critical ("decrypt: unhandled error value: %d", result);
+                break;
+        }
     }
 
     private void create_decrypted_view (string pv) {

--- a/src/Widgets/DecryptMenu.vala
+++ b/src/Widgets/DecryptMenu.vala
@@ -123,7 +123,7 @@ public class Installer.DecryptMenu: Gtk.Popover {
     }
 
     private async void decrypt (string pv) {
-        string password = pass_entry.get_text ();
+        unowned string password = pass_entry.get_text ();
 
         int result;
         try {

--- a/src/Widgets/DecryptMenu.vala
+++ b/src/Widgets/DecryptMenu.vala
@@ -81,7 +81,7 @@ public class Installer.DecryptMenu: Gtk.Popover {
         pass_entry.changed.connect (() => set_sensitivity ());
         pass_entry.activate.connect (() => {
             if (entries_set ()) {
-                decrypt (pv_entry.get_text ());
+                decrypt.begin (pv_entry.get_text ());
             }
         });
 
@@ -94,7 +94,7 @@ public class Installer.DecryptMenu: Gtk.Popover {
         pv_entry.changed.connect (() => set_sensitivity ());
         pv_entry.activate.connect (() => {
             if (entries_set ()) {
-                decrypt (pv_entry.get_text ());
+                decrypt.begin (pv_entry.get_text ());
             }
         });
 
@@ -103,7 +103,7 @@ public class Installer.DecryptMenu: Gtk.Popover {
         decrypt_button.sensitive = false;
         decrypt_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
         decrypt_button.clicked.connect (() => {
-            decrypt (pv_entry.get_text ());
+            decrypt.begin (pv_entry.get_text ());
         });
 
         decrypt_view = new Gtk.Grid ();

--- a/src/Widgets/DecryptMenu.vala
+++ b/src/Widgets/DecryptMenu.vala
@@ -125,7 +125,13 @@ public class Installer.DecryptMenu: Gtk.Popover {
     private async void decrypt (string pv) {
         string password = pass_entry.get_text ();
 
-        int result = yield Daemon.get_default ().decrypt_partition (device_path, pv_entry.get_text (), password);
+        int result;
+        try {
+            result = yield Daemon.get_default ().decrypt_partition (device_path, pv_entry.get_text (), password);
+        } catch (Error e) {
+            critical ("Unable to decrypt partition: %s", e.message);
+            return;
+        }
 
         switch (result) {
             case 0:

--- a/src/Widgets/PartitionBar.vala
+++ b/src/Widgets/PartitionBar.vala
@@ -31,7 +31,7 @@ public class Installer.PartitionBar : Gtk.EventBox {
     public Gtk.Popover menu;
     public Distinst.FileSystem filesystem;
 
-    public signal void decrypted (LuksCredentials credential);
+    public signal void decrypted (InstallerDaemon.LuksCredentials credential);
 
     public PartitionBar (InstallerDaemon.Partition part, string parent_path,
                          uint64 sector_size, bool lvm, SetMount set_mount,

--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -51,7 +51,7 @@ public class Installer.PartitionMenu : Gtk.Popover {
         partition_path = path;
         parent_disk = parent;
 
-        string boot_partition = (Distinst.bootloader_detect () == Distinst.PartitionTable.GPT)
+        string boot_partition = (Daemon.get_default ().bootloader_detect () == Distinst.PartitionTable.GPT)
             ? "/boot/efi"
             : "/boot";
 
@@ -177,7 +177,7 @@ public class Installer.PartitionMenu : Gtk.Popover {
             custom.visible = visible;
 
             if (active == 2) {
-                if (Distinst.bootloader_detect () == Distinst.PartitionTable.GPT) {
+                if (Daemon.get_default ().bootloader_detect () == Distinst.PartitionTable.GPT) {
                     type.active = 2;
                 } else {
                     type.active = 0;
@@ -344,7 +344,7 @@ public class Installer.PartitionMenu : Gtk.Popover {
             case 1:
                 return "/home";
             case 2:
-                if (Distinst.bootloader_detect () == Distinst.PartitionTable.GPT) {
+                if (Daemon.get_default ().bootloader_detect () == Distinst.PartitionTable.GPT) {
                     return "/boot/efi";
                 } else {
                     return "/boot";

--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -287,8 +287,8 @@ public class Installer.PartitionMenu : Gtk.Popover {
                 parent_disk,
                 mount,
                 partition_bar.end - partition_bar.start,
-                (format_partition.active ? Mount.Flags.FORMAT : 0)
-                    + (is_lvm ? Mount.Flags.LVM : 0),
+                (format_partition.active ? InstallerDaemon.MountFlags.FORMAT : 0)
+                    + (is_lvm ? InstallerDaemon.MountFlags.LVM : 0),
                 filesystem,
                 this
             ));

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,6 +3,7 @@ vala_files = [
     'MainWindow.vala',
     'Utils.vala',
     'Helpers/Inhibitor.vala',
+    'Helpers/InstallerDaemon.vala',
     'Helpers/KeyboardLayoutHelper.vala',
     'Helpers/LocaleHelper.vala',
     'Helpers/LogHelper.vala',
@@ -27,7 +28,8 @@ vala_files = [
     'Widgets/PartitionBar.vala',
     'Widgets/PartitionMenu.vala',
     'Widgets/Terminal.vala',
-    'Widgets/VariantWidget.vala'
+    'Widgets/VariantWidget.vala',
+    join_paths(meson.source_root(), 'common', 'DBusStructures.vala'),
 ]
 
 configuration_data = configuration_data()
@@ -51,7 +53,22 @@ config_file = configure_file(
     configuration: configuration_data
 )
 
+gui_dependencies = [
+    distinst_dep,
+    gee_dep,
+    glib_dep,
+    gnome_keyboard_dep,
+    gnome_keyboard_ui_dep,
+    gobject_dep,
+    granite_dep,
+    gtk_dep,
+    handy_dep,
+    json_glib_dep,
+    pwquality_dep,
+    xml2_dep
+]
+
 executable(meson.project_name(), vala_files, config_file,
            asresources,
-           dependencies : dependencies,
+           dependencies : gui_dependencies,
            install: true)

--- a/src/meson.build
+++ b/src/meson.build
@@ -29,7 +29,7 @@ vala_files = [
     'Widgets/PartitionMenu.vala',
     'Widgets/Terminal.vala',
     'Widgets/VariantWidget.vala',
-    join_paths(meson.source_root(), 'common', 'DBusStructures.vala'),
+    common_files,
 ]
 
 configuration_data = configuration_data()


### PR DESCRIPTION
Requires deb packaging branch: #479 

This looks like quite a scary diff, but it's largely just moving things out of the current installer process into a new daemon and then adding the necessary structures to communicate with it over DBus.

I've tested BIOS and UEFI installs with this branch, with both custom and default partitioning and all is working well.

The only thing this changes functionally is some of the hangs in the GUI where Distinst was doing stuff on the GUI thread. So things feel a little more responsive, especially around disk selection and partitioning now.

This doesn't yet make the necessary changes to have the GUI run as a standard user. I'll follow up with that in a separate branch as this one is getting kind of long.

It would be good to get this merged sooner rather than later so we can test for regressions in the daily isos and unblock the rest of the work around wrong theming, polkit stuff in the live session, keyboard layouts etc.