### PR TITLE
Strip locale string

### DIFF
--- a/src/Helpers/LocaleHelper.vala
+++ b/src/Helpers/LocaleHelper.vala
@@ -141,6 +141,7 @@ namespace LocaleHelper {
             );
 
             yield command.communicate_utf8_async (null, null, out locale, null);
+            locale = locale.strip ();
 
             return command.get_exit_status () == 0;
         } catch (Error e) {


### PR DESCRIPTION
Passing a string with a newline on the end of it was upsetting something and causing it to regenerate locales for all the things and take forever.