### PR TITLE
Add a minimal set of GSettings overrides

### DIFF
--- a/data/installer-default-settings.gschema.override
+++ b/data/installer-default-settings.gschema.override
@@ -1,0 +1,56 @@
+[org.freedesktop.ibus.general.hotkey:Installer]
+triggers=['<Control>space']
+
+[org.freedesktop.ibus.panel:Installer]
+show=1
+
+[org.gnome.desktop.datetime:Installer]
+automatic-timezone=true
+
+[org.gnome.desktop.input-sources:Installer]
+xkb-options=['grp:alt_shift_toggle']
+
+[org.gnome.desktop.interface:Installer]
+cursor-theme='elementary'
+document-font-name='Open Sans 10'
+font-name='Inter 9'
+gtk-theme='io.elementary.stylesheet.blueberry'
+icon-theme='elementary'
+monospace-font-name='Roboto Mono 10'
+show-unicode-menu=false
+
+[org.gnome.desktop.peripherals.touchpad:Installer]
+natural-scroll=true
+tap-to-click=true
+
+[org.gnome.desktop.sound:Installer]
+theme-name='elementary'
+
+[org.gnome.desktop.wm.preferences:Installer]
+button-layout='close:maximize'
+mouse-button-modifier='<Super>'
+resize-with-right-button=true
+
+[org.gnome.nm-applet:Installer]
+disable-connected-notifications=true
+show-applet=false
+
+[org.gnome.settings-daemon.peripherals.touchpad:Installer]
+horiz-scroll-enabled=true
+natural-scroll=true
+scroll-method='two-finger-scrolling'
+
+[org.gnome.settings-daemon.plugins.screensaver-proxy:Installer]
+# Allows light-locker to accept DBus
+active=false
+
+[org.gnome.settings-daemon.plugins.xsettings:Installer]
+antialiasing='grayscale'
+hinting='slight'
+overrides={'Gtk/DialogsUseHeader': <0>, 'Gtk/EnablePrimaryPaste': <0>, 'Gtk/ShellShowsAppMenu': <0>, 'Gtk/DecorationLayout': <'close:menu,maximize'>}
+
+[org.gtk.Settings.FileChooser:Installer]
+sort-directories-first=true
+
+[org.onboard:Installer]
+theme='/usr/share/onboard/themes/Nightshade.theme'

--- a/data/installer.session
+++ b/data/installer.session
@@ -2,4 +2,3 @@
 Name=Installer
 RequiredComponents=io.elementary.installer.compositor;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.XSettings;io.elementary.installer;
 DesktopName=Installer
-DesktopNames=Pantheon

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,4 +1,5 @@
 autostartdir = join_paths(get_option('sysconfdir'), 'xdg', 'autostart')
+schemadir = join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
 
 i18n.merge_file(
     input: meson.project_name() + '.desktop.in',
@@ -41,6 +42,11 @@ install_subdir(
 install_data(
     'installer.session',
     install_dir: join_paths(get_option('datadir'), 'gnome-session', 'sessions')
+)
+
+install_data(
+    'installer-default-settings.gschema.override',
+    install_dir: schemadir
 )
 
 # Test the desktop file


### PR DESCRIPTION
Fixes #477 

Requires deb-packaging PR: #485 

After some more consideration, we still need to keep the separate installer session. The installer itself can run fine as a standard user (so in theory it could run in the greeter). However, it still calls on gparted to do disk partitioning, which would need root permissions, which we wouldn't be able to get in the greeter.

So the best way to solve the current theming issues in the installer session is to ship a subset of the GSettings overrides in the installer package.