### PR TITLE
Remove pkexec from autostart file

### DIFF
--- a/data/autostart.desktop
+++ b/data/autostart.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Installer
-Exec=sh -c "pkexec env XDG_SEAT_PATH\=\$XDG_SEAT_PATH DISPLAY\=\$DISPLAY XAUTHORITY\=\$XAUTHORITY io.elementary.installer"
+Exec=io.elementary.installer
 Terminal=false
 Type=Application
 X-GNOME-Autostart-Notify=false


### PR DESCRIPTION
Decoupling this from #486 since it's mostly unrelated.

Fixes #253 

I've tested that you can still install successfully with these changes