### PR TITLE
Check requirements before disk selection

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -140,8 +140,6 @@ public class Installer.MainWindow : Hdy.Window {
         stack.add (encrypt_view);
         stack.visible_child = encrypt_view;
 
-        load_check_view ();
-
         encrypt_view.cancel.connect (() => {
             stack.visible_child = try_install_view;
         });
@@ -159,6 +157,8 @@ public class Installer.MainWindow : Hdy.Window {
         stack.add (disk_view);
         stack.visible_child = disk_view;
         disk_view.load.begin (CheckView.MINIMUM_SPACE);
+
+        load_check_view ();
 
         disk_view.cancel.connect (() => {
             stack.visible_child = try_install_view;


### PR DESCRIPTION
Fixes #501 

The current code only checks the system requirements after selecting a disk. Meaning you get stuck on the disk selection page with no explanation why the button to install onto your lone 12 GB disk is disabled.

This moves the check one step earlier, so you get an error saying there are no disks big enough first.