### PR TITLE
daemon: Skip read-only drives in disk probe

### DIFF
--- a/daemon/Daemon.vala
+++ b/daemon/Daemon.vala
@@ -50,6 +50,10 @@ public class InstallerDaemon.Daemon : GLib.Object {
         Disk[] logical_disks = {};
 
         foreach (unowned Distinst.Disk disk in disks.list ()) {
+            if (disk.is_read_only ()) {
+                continue;
+            }
+
             // Skip root disk or live disk
             if (disk.contains_mount ("/", disks) || disk.contains_mount ("/cdrom", disks)) {
                 continue;


### PR DESCRIPTION
When we're probing for potential disks to install to, we don't care about read-only drives (CD/DVD drives, etc), so lets skip over those.