### PR TITLE
TryInstallView: Rewrite as radiobuttons, code style

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -36,11 +36,11 @@ public class Installer.MainWindow : Hdy.Window {
     public MainWindow () {
         Object (
             deletable: false,
-            height_request: 700,
+            default_height: 700,
+            default_width: 950,
             icon_name: "system-os-installer",
             resizable: false,
             title: _("Install %s").printf (Utils.get_pretty_name ()),
-            width_request: 950,
             window_position: Gtk.WindowPosition.CENTER_ALWAYS
         );
     }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -36,11 +36,11 @@ public class Installer.MainWindow : Hdy.Window {
     public MainWindow () {
         Object (
             deletable: false,
-            default_height: 700,
-            default_width: 950,
+            height_request: 700,
             icon_name: "system-os-installer",
             resizable: false,
             title: _("Install %s").printf (Utils.get_pretty_name ()),
+            width_request: 950,
             window_position: Gtk.WindowPosition.CENTER_ALWAYS
         );
     }

--- a/src/Views/TryInstallView.vala
+++ b/src/Views/TryInstallView.vala
@@ -29,6 +29,7 @@ public class Installer.TryInstallView : AbstractInstallerView {
         };
         type_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
 
+        // Force the user to make a conscious selection, not spam "Next"
         var no_selection = new Gtk.RadioButton (null) {
             active = true
         };

--- a/src/Views/TryInstallView.vala
+++ b/src/Views/TryInstallView.vala
@@ -1,6 +1,5 @@
-// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2017–2018 elementary LLC. (https://elementary.io)
+ * Copyright 2017–2021 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,131 +19,101 @@ public class Installer.TryInstallView : AbstractInstallerView {
     public signal void custom_step ();
     public signal void next_step ();
 
-    private Gtk.Button next_button;
-
     construct {
-        var type_grid = new Gtk.Grid ();
-        type_grid.halign = Gtk.Align.CENTER;
-        type_grid.valign = Gtk.Align.CENTER;
-        type_grid.orientation = Gtk.Orientation.VERTICAL;
-        type_grid.vexpand = true;
-        type_grid.row_spacing = 6;
+        var type_image = new Gtk.Image.from_icon_name ("system-os-installer", Gtk.IconSize.DIALOG) {
+            valign = Gtk.Align.END
+        };
 
-        var type_scrolled = new Gtk.ScrolledWindow (null, null);
-        type_scrolled.vexpand = true;
-        type_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
-#if GTK_3_22
-        type_scrolled.propagate_natural_height = true;
-#endif
-        type_scrolled.add (type_grid);
+        var type_label = new Gtk.Label (_("Try or Install")) {
+            valign = Gtk.Align.START
+        };
+        type_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
 
-        var type_image = new Gtk.Image.from_icon_name ("system-os-installer", Gtk.IconSize.DIALOG);
-        type_image.valign = Gtk.Align.START;
-
-        var type_label = new Gtk.Label (_("Try or Install"));
-        type_label.hexpand = true;
-        type_label.get_style_context ().add_class ("h2");
-
-        var type_desc_label = new Gtk.Label (_("You can install %s on this device now, or try Demo Mode without installing.").printf (Utils.get_pretty_name ()));
-        type_desc_label.hexpand = true;
-        type_desc_label.max_width_chars = 60;
-        type_desc_label.wrap = true;
-
-        var title_grid = new Gtk.Grid ();
-        title_grid.column_spacing = 12;
-        title_grid.row_spacing = 6;
-        title_grid.halign = Gtk.Align.CENTER;
-        title_grid.valign = Gtk.Align.CENTER;
-        title_grid.attach (type_image, 0, 0, 1, 1);
-        title_grid.attach (type_label, 0, 1, 1, 1);
-        title_grid.attach (type_desc_label, 0, 2, 1, 1);
-
-        content_area.valign = Gtk.Align.FILL;
-        content_area.column_homogeneous = true;
-        content_area.attach (title_grid, 0, 0, 1, 1);
-        content_area.attach (type_scrolled, 1, 0, 1, 1);
-
-        var back_button = new Gtk.Button.with_label (_("Back"));
-        back_button.clicked.connect (() => ((Gtk.Stack) get_parent ()).visible_child = previous_view);
-
-        next_button = new Gtk.Button.with_label (_("Next"));
-        next_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
-        next_button.sensitive = false;
+        var no_selection = new Gtk.RadioButton (null) {
+            active = true
+        };
 
         var demo_button = new InstallTypeButton (
             _("Try Demo Mode"),
             "dialog-question",
             _("Changes will not be saved, and data from your previous OS will be unchanged. Performance and features may not reflect the installed experience.")
-        );
+        ) {
+            group = no_selection
+        };
 
         var clean_install_button = new InstallTypeButton (
             _("Clean Install"),
             "edit-clear",
             _("Erase everything and install a fresh copy of %s.").printf (Utils.get_pretty_name ())
-        );
+        ) {
+            group = no_selection
+        };
 
         var custom_button = new InstallTypeButton (
             _("Custom (Advanced)"),
             "system-run",
             _("Create, resize, or otherwise manage partitions manually. This method may lead to data loss.")
-        );
+        ) {
+            group = no_selection
+        };
 
-        action_area.add (back_button);
-        action_area.add (next_button);
-
+        var type_grid = new Gtk.Grid () {
+            orientation = Gtk.Orientation.VERTICAL,
+            row_spacing = 6,
+            valign = Gtk.Align.CENTER,
+            vexpand = true
+        };
         type_grid.add (demo_button);
         type_grid.add (clean_install_button);
         type_grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
         type_grid.add (custom_button);
 
+        var type_scrolled = new Gtk.ScrolledWindow (null, null) {
+            hscrollbar_policy = Gtk.PolicyType.NEVER,
+            propagate_natural_height = true
+        };
+        type_scrolled.add (type_grid);
+
+        content_area.column_homogeneous = true;
+        content_area.margin_end = 12;
+        content_area.margin_start = 12;
+        content_area.attach (type_image, 0, 0);
+        content_area.attach (type_label, 0, 1);
+        content_area.attach (type_scrolled, 1, 0, 1, 2);
+
+        var back_button = new Gtk.Button.with_label (_("Back"));
+
+        var next_button = new Gtk.Button.with_label (_("Next")) {
+            sensitive = false
+        };
+        next_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+
+        action_area.add (back_button);
+        action_area.add (next_button);
+
+        back_button.clicked.connect (() => ((Gtk.Stack) get_parent ()).visible_child = previous_view);
+
         demo_button.clicked.connect (() => {
             if (demo_button.active) {
-                type_grid.get_children ().foreach ((child) => {
-                    if (child is Gtk.ToggleButton) {
-                        ((Gtk.ToggleButton)child).active = child == demo_button;
-                    }
-                });
-
-                next_button.label = demo_button.type_title;
+                next_button.label = demo_button.title;
                 next_button.sensitive = true;
                 next_button.clicked.connect (Utils.demo_mode);
-            } else {
-                next_button.sensitive = false;
-                next_button.label = _("Next");
             }
         });
 
         clean_install_button.clicked.connect (() => {
             if (clean_install_button.active) {
-                type_grid.get_children ().foreach ((child) => {
-                    if (child is Gtk.ToggleButton) {
-                        ((Gtk.ToggleButton)child).active = child == clean_install_button;
-                    }
-                });
-
-                next_button.label = clean_install_button.type_title;
+                next_button.label = clean_install_button.title;
                 next_button.sensitive = true;
                 next_button.clicked.connect (() => next_step ());
-            } else {
-                next_button.sensitive = false;
-                next_button.label = _("Next");
             }
         });
 
         custom_button.clicked.connect (() => {
             if (custom_button.active) {
-                type_grid.get_children ().foreach ((child) => {
-                    if (child is Gtk.ToggleButton) {
-                        ((Gtk.ToggleButton)child).active = child == custom_button;
-                    }
-                });
-
-                next_button.label = custom_button.type_title;
+                next_button.label = custom_button.title;
                 next_button.sensitive = true;
                 next_button.clicked.connect (() => custom_step ());
-            } else {
-                next_button.sensitive = false;
-                next_button.label = _("Next");
             }
         });
 

--- a/src/Views/TryInstallView.vala
+++ b/src/Views/TryInstallView.vala
@@ -42,7 +42,7 @@ public class Installer.TryInstallView : AbstractInstallerView {
         };
 
         var clean_install_button = new InstallTypeButton (
-            _("Clean Install"),
+            _("Erase Disk and Install"),
             "edit-clear",
             _("Erase everything and install a fresh copy of %s.").printf (Utils.get_pretty_name ())
         ) {
@@ -50,7 +50,7 @@ public class Installer.TryInstallView : AbstractInstallerView {
         };
 
         var custom_button = new InstallTypeButton (
-            _("Custom (Advanced)"),
+            _("Custom Install (Advanced)"),
             "system-run",
             _("Create, resize, or otherwise manage partitions manually. This method may lead to data loss.")
         ) {
@@ -60,8 +60,7 @@ public class Installer.TryInstallView : AbstractInstallerView {
         var type_grid = new Gtk.Grid () {
             orientation = Gtk.Orientation.VERTICAL,
             row_spacing = 6,
-            valign = Gtk.Align.CENTER,
-            vexpand = true
+            valign = Gtk.Align.CENTER
         };
         type_grid.add (demo_button);
         type_grid.add (clean_install_button);
@@ -111,7 +110,7 @@ public class Installer.TryInstallView : AbstractInstallerView {
 
         custom_button.clicked.connect (() => {
             if (custom_button.active) {
-                next_button.label = custom_button.title;
+                next_button.label = _("Custom Install");
                 next_button.sensitive = true;
                 next_button.clicked.connect (() => custom_step ());
             }

--- a/src/Widgets/InstallTypeGrid.vala
+++ b/src/Widgets/InstallTypeGrid.vala
@@ -1,6 +1,5 @@
-// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*-
- * Copyright (c) 2018 elementary LLC. (https://elementary.io)
+ * Copyright 2018-2021 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,49 +17,43 @@
  * Authored by: Cassidy James Blaede <c@ssidyjam.es>
  */
 
-public class Installer.InstallTypeButton : Gtk.ToggleButton {
-    public string type_title { get; construct; }
+public class Installer.InstallTypeButton : Gtk.RadioButton {
+    public string title { get; construct; }
     public string icon_name { get; construct; }
-    public string type_subtitle { get; construct; }
+    public string subtitle { get; construct; }
 
-    public InstallTypeButton (string type_title, string icon_name, string type_subtitle) {
+    public InstallTypeButton (string title, string icon_name, string subtitle) {
         Object (
-            type_title: type_title,
+            title: title,
             icon_name: icon_name,
-            type_subtitle: type_subtitle
+            subtitle: subtitle
         );
     }
 
     construct {
-        get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        get_style_context ().add_class ("image-button");
 
-        var type_image = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.DIALOG);
-        type_image.use_fallback = true;
+        var image = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.DIALOG);
 
-        var title_label = new Gtk.Label (type_title);
-        title_label.halign = Gtk.Align.START;
-        title_label.hexpand = true;
-        title_label.valign = Gtk.Align.END;
+        var title_label = new Gtk.Label (title) {
+            wrap = true,
+            xalign = 0
+        };
         title_label.get_style_context ().add_class (Granite.STYLE_CLASS_PRIMARY_LABEL);
 
-        var subtitle_label = new Gtk.Label ("%s".printf (type_subtitle));
-        subtitle_label.halign = Gtk.Align.START;
-        subtitle_label.use_markup = true;
-        subtitle_label.max_width_chars = 45;
-        subtitle_label.valign = Gtk.Align.START;
-        subtitle_label.wrap = true;
-        subtitle_label.xalign = 0;
+        var subtitle_label = new Gtk.Label (subtitle) {
+            wrap = true,
+            xalign = 0
+        };
 
-        var grid = new Gtk.Grid ();
-        grid.margin = 6;
-        grid.margin_end = 12;
-        grid.column_spacing = 6;
-        grid.row_spacing = 6;
-        grid.orientation = Gtk.Orientation.VERTICAL;
-
-        grid.attach (type_image, 0, 0, 1, 2);
-        grid.attach (title_label, 1, 0, 1, 1);
-        grid.attach (subtitle_label, 1, 1, 1, 1);
+        var grid = new Gtk.Grid () {
+            column_spacing = 6,
+            row_spacing = 6,
+            margin = 6
+        };
+        grid.attach (image, 0, 0, 1, 2);
+        grid.attach (title_label, 1, 0);
+        grid.attach (subtitle_label, 1, 1);
 
         add (grid);
     }


### PR DESCRIPTION
Fixes #515 

![Screenshot from 2021-05-05 09 46 12](https://user-images.githubusercontent.com/7277719/117178294-be02a780-ad86-11eb-9775-c296226129c7.png)

* Remove redundant label in the title area. We don't use a label like this in the other preceding views
* Use radio buttons to make it obvious where the selection is, and very clear what the current selection is
* Incorporate some string changes from #510 
* Lots of code style and organizational cleanups