### PR TITLE
 TryInstallView: stop view from vexpanding the window

### DIFF
--- a/src/Views/TryInstallView.vala
+++ b/src/Views/TryInstallView.vala
@@ -68,18 +68,13 @@ public class Installer.TryInstallView : AbstractInstallerView {
         type_grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
         type_grid.add (custom_button);
 
-        var type_scrolled = new Gtk.ScrolledWindow (null, null) {
-            hscrollbar_policy = Gtk.PolicyType.NEVER,
-            propagate_natural_height = true
-        };
-        type_scrolled.add (type_grid);
-
         content_area.column_homogeneous = true;
         content_area.margin_end = 12;
         content_area.margin_start = 12;
+        content_area.valign = Gtk.Align.CENTER;
         content_area.attach (type_image, 0, 0);
         content_area.attach (type_label, 0, 1);
-        content_area.attach (type_scrolled, 1, 0, 1, 2);
+        content_area.attach (type_grid, 1, 0, 1, 2);
 
         var back_button = new Gtk.Button.with_label (_("Back"));
 

--- a/src/Views/TryInstallView.vala
+++ b/src/Views/TryInstallView.vala
@@ -68,13 +68,19 @@ public class Installer.TryInstallView : AbstractInstallerView {
         type_grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
         type_grid.add (custom_button);
 
+        var type_scrolled = new Gtk.ScrolledWindow (null, null) {
+            hscrollbar_policy = Gtk.PolicyType.NEVER,
+            propagate_natural_height = true
+        };
+        type_scrolled.add (type_grid);
+
         content_area.column_homogeneous = true;
         content_area.margin_end = 12;
         content_area.margin_start = 12;
         content_area.valign = Gtk.Align.CENTER;
         content_area.attach (type_image, 0, 0);
         content_area.attach (type_label, 0, 1);
-        content_area.attach (type_grid, 1, 0, 1, 2);
+        content_area.attach (type_scrolled, 1, 0, 1, 2);
 
         var back_button = new Gtk.Button.with_label (_("Back"));
 

--- a/src/Widgets/InstallTypeGrid.vala
+++ b/src/Widgets/InstallTypeGrid.vala
@@ -36,12 +36,13 @@ public class Installer.InstallTypeButton : Gtk.RadioButton {
         var image = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.DIALOG);
 
         var title_label = new Gtk.Label (title) {
-            wrap = true,
+            hexpand = true,
             xalign = 0
         };
         title_label.get_style_context ().add_class (Granite.STYLE_CLASS_PRIMARY_LABEL);
 
         var subtitle_label = new Gtk.Label (subtitle) {
+            max_width_chars = 1, // Make Gtk wrap, but not expand the window
             wrap = true,
             xalign = 0
         };


### PR DESCRIPTION
* Don't wrap title label, this preserves extra space
* Add max_width_chars to subtitle to force the wrap