### PR TITLE
MainWindow: Use default height/width

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -36,11 +36,11 @@ public class Installer.MainWindow : Hdy.Window {
     public MainWindow () {
         Object (
             deletable: false,
-            height_request: 700,
+            default_height: 600,
+            default_width: 850,
             icon_name: "system-os-installer",
             resizable: false,
             title: _("Install %s").printf (Utils.get_pretty_name ()),
-            width_request: 950,
             window_position: Gtk.WindowPosition.CENTER_ALWAYS
         );
     }


### PR DESCRIPTION
height and width request enforce a minimum size, so the window can't be made smaller. Use default height/width instead. This probably doesn't stop the window from being created larger than the screen, but it's a step :shrug: 

These values are much smaller because height/width request apparently includes the shadow or something? But the window itself is the same size afaict