### PR TITLE
Debian control: Point to RDNN greeter dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Homepage: https://github.com/elementary/installer
 Package: io.elementary.installer
 Architecture: amd64
 Priority: extra
-Depends: distinst, gparted, pantheon-greeter, wingpanel, ${misc:Depends}, ${shlibs:Depends}
+Depends: distinst, gparted, io.elementary.greeter, wingpanel, ${misc:Depends}, ${shlibs:Depends}
 Recommends: io.elementary.installer-session, io.elementary.onboarding
 Description: Distribution installer
  Installs distros with ease, all installs are treated as OEM.


### PR DESCRIPTION
OS builds are failing because the installer can't be installed.