### PR TITLE
Fallback when generated hostname is invalid

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -264,6 +264,10 @@ namespace Utils {
         string hostname = get_ubiquity_compatible_hostname () ?? ("elementary-os" + "-" + get_chassis ());
         hostname += "-" + get_machine_id ().substring (0, 8);
 
+        if (!Distinst.validate_hostname (hostname)) {
+            hostname = "elementary-os";
+        }
+
         return hostname;
     }
 }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -264,6 +264,9 @@ namespace Utils {
         string hostname = get_ubiquity_compatible_hostname () ?? ("elementary-os" + "-" + get_chassis ());
         hostname += "-" + get_machine_id ().substring (0, 8);
 
+        // If the automatic hostname logic fails in some way, it's possible we may generate an invalid
+        // hostname. We could fix this by trimming traling/leading hyphens or other invalid characters.
+        // But it's probably a bad hostname anyway, so just fallback
         if (!Distinst.validate_hostname (hostname)) {
             hostname = "elementary-os";
         }


### PR DESCRIPTION
Fixes #600 

I've tested this method behaves as expected by passing it some valid and invalid hostnames and logging results to the console. So this should be a quick fix to any invalid hostnames that are being generated on various bits of hardware that are producing weird results for the automatic logic.