### PR TITLE
ProgressView.css: replace accent_color with BLUEBERRY

### DIFF
--- a/data/ProgressView.css
+++ b/data/ProgressView.css
@@ -3,7 +3,7 @@ avatar.image {
     background-image: linear-gradient(
         to bottom,
         alpha(@BLUEBERRY_500, 0.25),
-        alpha(@accent_color_700, 0.75)
+        alpha(@BLUEBERRY_700, 0.75)
     );
 }
 
@@ -20,7 +20,7 @@ avatar.image {
         background-image: linear-gradient(
             to bottom,
             alpha(@BLUEBERRY_500, 0.25),
-            alpha(@accent_color_700, 0.75)
+            alpha(@BLUEBERRY_700, 0.75)
         );
     }
 


### PR DESCRIPTION
Same fix from #583 but without the `from, to`. It doesn't appear that that's valid Gtk.CSS even though it should work in proper CSS