### PR TITLE
CheckView: Fix wrong gettext syntax

### DIFF
--- a/src/Views/CheckView.vala
+++ b/src/Views/CheckView.vala
@@ -216,7 +216,7 @@ public class Installer.CheckView : AbstractInstallerView {
             case State.SPACE:
                 var grid = new CheckView (
                     _("Not Enough Space"),
-                    _("There is not enough room on your device to install %s. We recommend a minimum of %s of storage.".printf (Utils.get_pretty_name (), GLib.format_size (MINIMUM_SPACE))),
+                    _("There is not enough room on your device to install %s. We recommend a minimum of %s of storage.").printf (Utils.get_pretty_name (), GLib.format_size (MINIMUM_SPACE)),
                     "drive-harddisk"
                 );
 


### PR DESCRIPTION
This fixes the string always showing in English regardless of the selected language
