### PR TITLE
MainWindow: throw an infobar on battery

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -23,6 +23,7 @@ public interface UPower : GLib.Object {
 }
 
 public class Installer.MainWindow : Hdy.Window {
+    private Gtk.Label infobar_label;
     private Gtk.Stack stack;
 
     private LanguageView language_view;
@@ -36,7 +37,6 @@ public class Installer.MainWindow : Hdy.Window {
     private EncryptView encrypt_view;
     private ErrorView error_view;
     private bool check_ignored = false;
-
 
     public MainWindow () {
         Object (
@@ -60,14 +60,10 @@ public class Installer.MainWindow : Hdy.Window {
         };
         stack.add (language_view);
 
-        var infobar_string = "%s\n%s".printf (
-            _("Connect to a Power Source"),
-            Granite.TOOLTIP_SECONDARY_TEXT_MARKUP.printf (_("Your device is running on battery power. It's recommended to be plugged in while installing."))
-        );
-
-        var infobar_label = new Gtk.Label (infobar_string) {
+        infobar_label = new Gtk.Label ("") {
             use_markup = true
         };
+        set_infobar_string ();
 
         var battery_infobar = new Gtk.InfoBar () {
             message_type = Gtk.MessageType.WARNING,
@@ -89,7 +85,7 @@ public class Installer.MainWindow : Hdy.Window {
 
         language_view.next_step.connect (() => {
             // Reset when language selection changes
-            infobar_label.label = infobar_string;
+            set_infobar_string ();
             load_keyboard_view ();
         });
 
@@ -270,5 +266,14 @@ public class Installer.MainWindow : Hdy.Window {
         stack.visible_child = error_view;
 
         error_view.previous_view = disk_view;
+    }
+
+    private void set_infobar_string () {
+        var infobar_string = "%s\n%s".printf (
+            _("Connect to a Power Source"),
+            Granite.TOOLTIP_SECONDARY_TEXT_MARKUP.printf (_("Your device is running on battery power. It's recommended to be plugged in while installing."))
+        );
+
+        infobar_label.label = infobar_string;
     }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -60,12 +60,12 @@ public class Installer.MainWindow : Hdy.Window {
         };
         stack.add (language_view);
 
-        var infobar_label = new Gtk.Label (
-            "%s\n%s".printf (
-                _("Connect to a Power Source"),
-                Granite.TOOLTIP_SECONDARY_TEXT_MARKUP.printf (_("Your device is running on battery power. It's recommended to be plugged in while installing."))
-            )
-        ) {
+        var infobar_string = "%s\n%s".printf (
+            _("Connect to a Power Source"),
+            Granite.TOOLTIP_SECONDARY_TEXT_MARKUP.printf (_("Your device is running on battery power. It's recommended to be plugged in while installing."))
+        );
+
+        var infobar_label = new Gtk.Label (infobar_string) {
             use_markup = true
         };
 
@@ -87,7 +87,11 @@ public class Installer.MainWindow : Hdy.Window {
 
         add (overlay);
 
-        language_view.next_step.connect (() => load_keyboard_view ());
+        language_view.next_step.connect (() => {
+            // Reset when language selection changes
+            infobar_label.label = infobar_string;
+            load_keyboard_view ();
+        });
 
         try {
             UPower upower = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.UPower", "/org/freedesktop/UPower", GLib.DBusProxyFlags.GET_INVALIDATED_PROPERTIES);


### PR DESCRIPTION
Currently, if you go from powered to battery we throw you from wherever you were into the CheckView to warn you about installing on battery power. This branch throws an infobar covering the beginning of the action area instead.

The reasoning behind the placement here is to making sure you can still complete the language view if this is shown on startup. Another alternative would be waiting to throw the infobar until after you've completed the language view and then we could show it in the more traditional top aligned location

![Screenshot from 2022-04-30 11 15 37](https://user-images.githubusercontent.com/7277719/166118191-473f8240-1b6e-465b-b2a9-25ef600fbb3c.png)
