### PR TITLE
CheckView: Ignore → Install Anyway

### DIFF
--- a/src/Views/CheckView.vala
+++ b/src/Views/CheckView.vala
@@ -81,7 +81,7 @@ public class Installer.CheckView : AbstractInstallerView {
         content_area.attach (title_label, 0, 1);
         content_area.attach (message_box, 1, 0, 1, 2);
 
-        var ignore_button = new Gtk.Button.with_label (_("Ignore"));
+        var ignore_button = new Gtk.Button.with_label (_("Install Anyway"));
         ignore_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
         ignore_button.clicked.connect (() => next_step ());
 


### PR DESCRIPTION
"Ignore" is kind of ambiguous. It tells us what will happen to this view, but it doesn't tell us what happens if we ignore. We have [precedent](https://github.com/search?q=org:elementary+anyway&type=code) for "[Action] Anyway" in these kinds of warnings which I think is more explicit about what you're agreeing to do when you ignore the warning