### PR TITLE
daemon: Deactivate LVM devices before install

### DIFF
--- a/daemon/Daemon.vala
+++ b/daemon/Daemon.vala
@@ -181,6 +181,9 @@ public class InstallerDaemon.Daemon : GLib.Object {
     }
 
     private void install (InstallConfig config, owned Distinst.Disks disks) {
+        // Ensure existing LVM devices are deactivated before installing
+        Distinst.deactivate_logical_devices ();
+
         var installer = new Distinst.Installer ();
         installer.on_error ((error) => on_error (error));
         installer.on_status ((status) => on_status (status));


### PR DESCRIPTION
I think this may fix the failure to clean install over an existing installation issue but I'll test this out in a VM now before marking it ready