### PR TITLE
CI: don't run on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [master]
   pull_request:
     types:
       - opened


### PR DESCRIPTION
CI is already run on every pull request there's no reason to run lint or build after merging something into main