### PR TITLE
Settings Overrides: Remove old keys

### DIFF
--- a/data/installer-default-settings.gschema.override
+++ b/data/installer-default-settings.gschema.override
@@ -17,7 +17,6 @@ font-name='Inter 9'
 gtk-theme='io.elementary.stylesheet.blueberry'
 icon-theme='elementary'
 monospace-font-name='Roboto Mono 10'
-show-unicode-menu=false
 
 [org.gnome.desktop.peripherals.touchpad:Installer]
 natural-scroll=true
@@ -45,8 +44,6 @@ scroll-method='two-finger-scrolling'
 active=false
 
 [org.gnome.settings-daemon.plugins.xsettings:Installer]
-antialiasing='grayscale'
-hinting='slight'
 overrides={'Gtk/DialogsUseHeader': <0>, 'Gtk/EnablePrimaryPaste': <0>, 'Gtk/ShellShowsAppMenu': <0>, 'Gtk/DecorationLayout': <'close:menu,maximize'>}
 
 [org.gtk.Settings.FileChooser:Installer]


### PR DESCRIPTION
Removes old settings keys that don't exist anymore

![Screenshot from 2023-11-17 08 36 49](https://github.com/elementary/installer/assets/7277719/9978bebb-f0fd-406e-9e15-f9f3a6fdfd45)
