### PR TITLE
PartitionBar: cleanup and code style

### DIFF
--- a/data/disk-bar-fallback.css
+++ b/data/disk-bar-fallback.css
@@ -18,7 +18,7 @@
  */
 
 levelbar block {
-    border-radius: 3px;
+    border-radius: 0.333em;
 }
 
 levelbar block:not(:first-child) {
@@ -84,6 +84,7 @@ levelbar block.unused {
 }
 
 levelbar block image {
+    padding: 0.5em;
     -gtk-icon-palette: error #fff, success #fff, warning #fff;
     -gtk-icon-shadow:
         0 1px 1px alpha(#000, 0.2),

--- a/src/Widgets/DiskBar.vala
+++ b/src/Widgets/DiskBar.vala
@@ -89,7 +89,7 @@ public class Installer.DiskBar: Gtk.Grid {
         legend.add (legend_container);
 
         foreach (PartitionBar p in partitions) {
-            add_legend (p.path, p.get_size () * 512, Distinst.strfilesys (p.filesystem), p.vg, p.menu);
+            add_legend (p.partition.device_path, p.get_size () * 512, Distinst.strfilesys (p.partition.filesystem), p.volume_group, p.menu);
         }
 
         uint64 used = 0;

--- a/src/Widgets/PartitionBar.vala
+++ b/src/Widgets/PartitionBar.vala
@@ -1,80 +1,48 @@
-// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
-/*-
- * Copyright (c) 2018 elementary LLC. (https://elementary.io)
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2018-2024 elementary, Inc. (https://elementary.io)
  *
  * Authored by: Michael Aaron Murphy <michael@system76.com>
  */
 
-public class Installer.PartitionBar : Gtk.EventBox {
-    public Gtk.Box container;
-
-    public uint64 start;
-    public uint64 end;
-    public uint64 used;
-    public new string path;
-    public string? vg;
-
-    public Gtk.Label label;
-    public Gtk.Popover menu;
-    public Distinst.FileSystem filesystem;
-
+public class Installer.PartitionBar : Gtk.Box {
     public signal void decrypted (InstallerDaemon.LuksCredentials credential);
 
-    public PartitionBar (InstallerDaemon.Partition part, string parent_path,
-                         uint64 sector_size, bool lvm, SetMount set_mount,
-                         UnsetMount unset_mount, MountSetFn mount_set) {
-        start = part.start_sector;
-        end = part.end_sector;
+    public Icon? icon { get; set; default = null; }
 
-        var usage = part.sectors_used;
-        if (usage.tag == 1) {
-            used = usage.value;
-        } else {
-            used = end - start;
-        }
+    public bool lvm { get; construct; }
+    public InstallerDaemon.Partition partition { get; construct; }
+    public string parent_path { get; construct; }
 
-        path = part.device_path;
-        filesystem = part.filesystem;
-        vg = (Distinst.FileSystem.LVM == filesystem)
-            ? part.current_lvm_volume_group
-            : null;
-        tooltip_text = path;
+    public string? volume_group { get; private set; }
+    public Gtk.Popover menu { get; private set; }
 
-        var style_context = get_style_context ();
-        style_context.add_class (Distinst.strfilesys (filesystem));
+    private Gtk.GestureMultiPress click_gesture;
 
-        container = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+    public PartitionBar (
+        InstallerDaemon.Partition partition,
+        string parent_path,
+        uint64 sector_size,
+        bool lvm,
+        SetMount set_mount,
+        UnsetMount unset_mount,
+        MountSetFn mount_set
+    ) {
+        Object (
+            lvm: lvm,
+            parent_path: parent_path,
+            partition: partition
+        );
 
-        if (filesystem == Distinst.FileSystem.LUKS) {
-            menu = new DecryptMenu (path);
+        if (partition.filesystem == LUKS) {
+            menu = new DecryptMenu (partition.device_path);
             ((DecryptMenu)menu).decrypted.connect ((creds) => decrypted (creds));
         } else {
-            menu = new PartitionMenu (path, parent_path, filesystem, lvm,
-                                      set_mount, unset_mount, mount_set, this);
+            menu = new PartitionMenu (partition.device_path, parent_path, partition.filesystem, lvm, set_mount, unset_mount, mount_set, this);
         }
 
-        menu.relative_to = container;
-        menu.position = Gtk.PositionType.BOTTOM;
-
-        add (container);
-        add_events (Gdk.EventMask.BUTTON_PRESS_MASK);
-        button_press_event.connect (() => {
-            show_popover ();
-            return true;
-        });
+        menu.relative_to = this;
+        menu.position = BOTTOM;
     }
 
     class construct {
@@ -82,24 +50,34 @@ public class Installer.PartitionBar : Gtk.EventBox {
     }
 
     construct {
+        volume_group = (partition.filesystem == LVM) ? partition.current_lvm_volume_group : null;
+
+        var image = new Gtk.Image () {
+            hexpand = true,
+            halign = END,
+            valign = END
+        };
+
+        add (image);
         hexpand = true;
+        tooltip_text = partition.device_path;
+
+        get_style_context ().add_class (Distinst.strfilesys (partition.filesystem));
+
+        click_gesture = new Gtk.GestureMultiPress (this);
+        click_gesture.released.connect (menu.popup);
+
+        bind_property ("icon", image, "gicon", SYNC_CREATE);
     }
 
     public uint64 get_size () {
-        return end - start;
-    }
-
-    public double get_percent (uint64 disk_sectors) {
-        return (((double) this.get_size () / (double) disk_sectors));
+        return partition.end_sector - partition.start_sector;
     }
 
     public int calculate_length (int alloc_width, uint64 disk_sectors) {
-        var request = alloc_width * get_percent (disk_sectors);
+        var percent = ((double) get_size () / (double) disk_sectors);
+        var request = alloc_width * percent;
         if (request < 20) request = 20;
         return (int) request;
-    }
-
-    public void show_popover () {
-        menu.popup ();
     }
 }

--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -222,7 +222,7 @@ public class Installer.PartitionMenu : Gtk.Popover {
                 update_values (set_mount);
             } else {
                 unset_mount (partition_path);
-                partition_bar.container.get_children ().foreach ((c) => c.destroy ());
+                partition_bar.icon = null;
             }
 
             bottom_revealer.reveal_child = use_partition.active;
@@ -238,7 +238,7 @@ public class Installer.PartitionMenu : Gtk.Popover {
         type.visible = true;
         custom.visible = false;
         disable_signals = false;
-        partition_bar.container.get_children ().foreach ((c) => c.destroy ());
+        partition_bar.icon = null;
     }
 
     private void set_format_sensitivity () {
@@ -265,7 +265,7 @@ public class Installer.PartitionMenu : Gtk.Popover {
                 partition_path,
                 parent_disk,
                 mount,
-                partition_bar.end - partition_bar.start,
+                partition_bar.get_size (),
                 (format_partition.active ? InstallerDaemon.MountFlags.FORMAT : 0)
                     + (is_lvm ? InstallerDaemon.MountFlags.LVM : 0),
                 filesystem,
@@ -275,22 +275,13 @@ public class Installer.PartitionMenu : Gtk.Popover {
             error = why.message;
         }
 
-        var mount_icon = new Gtk.Image.from_icon_name (
-            error == null ? "process-completed-symbolic" : "dialog-warning-symbolic",
-            Gtk.IconSize.SMALL_TOOLBAR
-        ) {
-            halign = Gtk.Align.END,
-            valign = Gtk.Align.END,
-            margin = 6
-        };
+        partition_bar.icon = new ThemedIcon (
+            error == null ? "process-completed-symbolic" : "dialog-warning-symbolic"
+        );
 
         if (error != null) {
             partition_bar.tooltip_text = error;
         }
-
-        partition_bar.container.get_children ().foreach ((c) => c.destroy ());
-        partition_bar.container.pack_start (mount_icon, true, true, 0);
-        partition_bar.container.show_all ();
     }
 
     private bool has_same_filesystem () {


### PR DESCRIPTION
* Use Gtk.Gesture instead of EventBox with button press event
* GObject style as much as possible
* Reduce the number of public properties, especially since `partition` is already a construction property
* Remove dead code
* Add a simple icon property instead of other classes changing this classes widget children
* clarify a couple property names
* Code style