### PR TITLE
Remove builtin flag from installer session

### DIFF
--- a/data/installer.desktop
+++ b/data/installer.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Installer
 Comment=This session provides elementary experience
-Exec=gnome-session --builtin --session=installer
+Exec=gnome-session --session=installer
 DesktopNames=Installer
 Type=Application


### PR DESCRIPTION
I believe this is the cause of the crashes in the live session in the daily ISOs.

I haven't looked to see if we also need to do some systemd stuff as well as this, but removing this from the ISO at least makes the crashing stop.