### PR TITLE
PartitionBar: make sure we get click events

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@ gnome = import('gnome')
 i18n = import('i18n')
 
 distinst_dep = dependency('distinst')
-glib_dep = dependency('glib-2.0')
+glib_dep = dependency('glib-2.0', version: '>=2.74')
 gobject_dep = dependency('gobject-2.0')
 gtk_dep = dependency('gtk+-3.0')
 gee_dep = dependency('gee-0.8')

--- a/src/Views/KeyboardLayoutView.vala
+++ b/src/Views/KeyboardLayoutView.vala
@@ -186,7 +186,7 @@ public class KeyboardLayoutView : AbstractInstallerView {
 
         show_all ();
 
-        Idle.add (() => {
+        Idle.add_once (() => {
             string? country = Configuration.get_default ().country;
             if (country != null) {
                 string default_layout = country.down ();

--- a/src/Widgets/PartitionBar.vala
+++ b/src/Widgets/PartitionBar.vala
@@ -5,7 +5,7 @@
  * Authored by: Michael Aaron Murphy <michael@system76.com>
  */
 
-public class Installer.PartitionBar : Gtk.Box {
+public class Installer.PartitionBar : Gtk.EventBox {
     public signal void decrypted (InstallerDaemon.LuksCredentials credential);
 
     public Icon? icon { get; set; default = null; }
@@ -43,6 +43,9 @@ public class Installer.PartitionBar : Gtk.Box {
 
         menu.relative_to = this;
         menu.position = BOTTOM;
+
+        click_gesture = new Gtk.GestureMultiPress (this);
+        click_gesture.released.connect (menu.popup);
     }
 
     class construct {
@@ -63,9 +66,6 @@ public class Installer.PartitionBar : Gtk.Box {
         tooltip_text = partition.device_path;
 
         get_style_context ().add_class (Distinst.strfilesys (partition.filesystem));
-
-        click_gesture = new Gtk.GestureMultiPress (this);
-        click_gesture.released.connect (menu.popup);
 
         bind_property ("icon", image, "gicon", SYNC_CREATE);
     }


### PR DESCRIPTION
Fixes #763
Closes #767 

I can't actually get the menu to popup in this branch or any previous commit since the last release, but this makes sure the gesture sends the event at least. Maybe the menu only works in an actual installer session for some reason?