### PR TITLE
VariantWidget: Gtk4 prep

### DIFF
--- a/src/Widgets/VariantWidget.vala
+++ b/src/Widgets/VariantWidget.vala
@@ -1,23 +1,11 @@
-/*-
- * Copyright 2017-2020 elementary, Inc. (https://elementary.io)
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2017-2023 elementary, Inc. (https://elementary.io)
  */
 
 public class VariantWidget : Gtk.Frame {
-    public Gtk.ListBox main_listbox { public get; private set; }
-    public Gtk.ListBox variant_listbox { public get; private set; }
+    public Gtk.ListBox main_listbox { get; private set; }
+    public Gtk.ListBox variant_listbox { get; private set; }
 
     public signal void going_to_main ();
 
@@ -52,13 +40,18 @@ public class VariantWidget : Gtk.Frame {
         };
         back_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
 
-        variant_title = new Gtk.Label (null);
-        variant_title.ellipsize = Pango.EllipsizeMode.END;
-        variant_title.max_width_chars = 20;
-        variant_title.use_markup = true;
+        variant_title = new Gtk.Label ("") {
+            hexpand = true,
+            justify = CENTER,
+            margin_end = 6,
+            margin_start = 6,
+            use_markup = true,
+            wrap = true
+        };
 
-        var header_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
-        header_box.hexpand = true;
+        var header_box = new Gtk.Box (HORIZONTAL, 0) {
+            hexpand = true
+        };
         header_box.add (back_button);
         header_box.set_center_widget (variant_title);
 
@@ -74,11 +67,12 @@ public class VariantWidget : Gtk.Frame {
         deck.add (main_scrolled);
         deck.add (variant_box);
 
-        add (deck);
+        child = deck;
+        vexpand = true;
 
         back_button.clicked.connect (() => {
             going_to_main ();
-            deck.navigate (Hdy.NavigationDirection.BACK);
+            deck.navigate (BACK);
         });
     }
 


### PR DESCRIPTION
Based on changes from:
- https://github.com/elementary/initial-setup/pull/174/files
- https://github.com/elementary/initial-setup/pull/134/files#diff-c8863692580f666c84bfe20b6e708e218ec13598a4756ea0f13828d3189b9650


* Code style
* Variant title wraps instead of truncates
* use child property
* Prepare for CenterBox