### PR TITLE
Gtk4 Prep: don't use primary label

### DIFF
--- a/src/Views/LanguageView.vala
+++ b/src/Views/LanguageView.vala
@@ -49,7 +49,7 @@ public class Installer.LanguageView : AbstractInstallerView {
 
         select_stack = new Gtk.Stack ();
         select_stack.valign = Gtk.Align.START;
-        select_stack.get_style_context ().add_class ("h2");
+        select_stack.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
         select_stack.transition_type = Gtk.StackTransitionType.CROSSFADE;
         select_stack.add (select_label);
 

--- a/src/Views/SuccessView.vala
+++ b/src/Views/SuccessView.vala
@@ -37,7 +37,7 @@ public class SuccessView : AbstractInstallerView {
             wrap = true,
             xalign = 0
         };
-        primary_label.get_style_context ().add_class (Granite.STYLE_CLASS_PRIMARY_LABEL);
+        primary_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
         secondary_label = new Gtk.Label (null) {
             max_width_chars = 1, // Make Gtk wrap, but not expand the window

--- a/src/Widgets/DecryptMenu.vala
+++ b/src/Widgets/DecryptMenu.vala
@@ -61,7 +61,7 @@ public class Installer.DecryptMenu: Gtk.Popover {
         overlay.add_overlay (overlay_image);
 
         var primary_label = new Gtk.Label (_("Decrypt This Partition"));
-        primary_label.get_style_context ().add_class (Granite.STYLE_CLASS_PRIMARY_LABEL);
+        primary_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
         primary_label.halign = Gtk.Align.START;
 
         var secondary_label = new Gtk.Label (_("Enter the partition's encryption password and set a device name for the decrypted partition."));

--- a/src/Widgets/DiskGrid.vala
+++ b/src/Widgets/DiskGrid.vala
@@ -44,7 +44,7 @@ public class Installer.DiskButton : Gtk.RadioButton {
             halign = Gtk.Align.START,
             valign = Gtk.Align.END
         };
-        name_label.get_style_context ().add_class (Granite.STYLE_CLASS_PRIMARY_LABEL);
+        name_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
         var size_label = new Gtk.Label ("%s %s".printf (disk_path, GLib.format_size (size))) {
             ellipsize = Pango.EllipsizeMode.MIDDLE,

--- a/src/Widgets/InstallTypeGrid.vala
+++ b/src/Widgets/InstallTypeGrid.vala
@@ -39,7 +39,7 @@ public class Installer.InstallTypeButton : Gtk.RadioButton {
             hexpand = true,
             xalign = 0
         };
-        title_label.get_style_context ().add_class (Granite.STYLE_CLASS_PRIMARY_LABEL);
+        title_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
         var subtitle_label = new Gtk.Label (subtitle) {
             max_width_chars = 1, // Make Gtk wrap, but not expand the window


### PR DESCRIPTION
There is no more PRIMARY class in Gtk4, so use H3 instead since that's the closest thing

Also fix an instance where we weren't using a constant at all