### PR TITLE
Widgets: Rename PartitionBar to PartitionBlock

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -23,6 +23,6 @@ src/Widgets/DecryptMenu.vala
 src/Widgets/DiskBar.vala
 src/Widgets/DiskGrid.vala
 src/Widgets/InstallTypeGrid.vala
-src/Widgets/PartitionBar.vala
+src/Widgets/PartitionBlock.vala
 src/Widgets/PartitionMenu.vala
 src/Widgets/VariantWidget.vala

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -172,9 +172,9 @@ public class Installer.PartitioningView : AbstractInstallerView {
 
             unowned string path = disk.device_path;
 
-            var partitions = new Gee.ArrayList<PartitionBar> ();
+            var partitions = new Gee.ArrayList<PartitionBlock> ();
             foreach (unowned InstallerDaemon.Partition part in disk.partitions) {
-                var partition = new PartitionBar (part, path, sector_size, false, this.set_mount, this.unset_mount, this.mount_is_set);
+                var partition = new PartitionBlock (part, path, sector_size, false, this.set_mount, this.unset_mount, this.mount_is_set);
                 partition.decrypted.connect (on_partition_decrypted);
                 partitions.add (partition);
             }
@@ -225,9 +225,9 @@ public class Installer.PartitioningView : AbstractInstallerView {
 
         unowned string path = disk.device_path;
 
-        var partitions = new Gee.ArrayList<PartitionBar> ();
+        var partitions = new Gee.ArrayList<PartitionBlock> ();
         foreach (unowned InstallerDaemon.Partition part in disk.partitions) {
-            var partition = new PartitionBar (part, path, sector_size, true, this.set_mount, this.unset_mount, this.mount_is_set);
+            var partition = new PartitionBlock (part, path, sector_size, true, this.set_mount, this.unset_mount, this.mount_is_set);
             partition.decrypted.connect (on_partition_decrypted);
             partitions.add (partition);
         }

--- a/src/Widgets/DiskBar.vala
+++ b/src/Widgets/DiskBar.vala
@@ -9,11 +9,11 @@ public class Installer.DiskBar: Gtk.Box {
     public string disk_name { get; construct; }
     public string disk_path { get; construct; }
     public uint64 size { get; construct; }
-    public Gee.ArrayList<PartitionBar> partitions { get; construct; }
+    public Gee.ArrayList<PartitionBlock> partitions { get; construct; }
 
     private Gtk.Box legend_box;
 
-    public DiskBar (string disk_name, string disk_path, uint64 size, Gee.ArrayList<PartitionBar> partitions) {
+    public DiskBar (string disk_name, string disk_path, uint64 size, Gee.ArrayList<PartitionBlock> partitions) {
         Object (
             disk_name: disk_name,
             disk_path: disk_path,
@@ -37,7 +37,7 @@ public class Installer.DiskBar: Gtk.Box {
             halign = START
         };
 
-        foreach (PartitionBar p in partitions) {
+        foreach (PartitionBlock p in partitions) {
             add_legend (
                 p.partition.device_path,
                 p.get_partition_size () * 512,
@@ -48,7 +48,7 @@ public class Installer.DiskBar: Gtk.Box {
         }
 
         uint64 used = 0;
-        foreach (PartitionBar partition in partitions) {
+        foreach (PartitionBlock partition in partitions) {
             used += partition.get_partition_size ();
         }
 
@@ -110,10 +110,10 @@ public class Installer.DiskBar: Gtk.Box {
     }
 
     private class PartitionContainer : Gtk.Widget {
-        public Gee.ArrayList<PartitionBar> partitions { get; construct; }
+        public Gee.ArrayList<PartitionBlock> partitions { get; construct; }
         public uint64 size { get; construct; }
 
-        public PartitionContainer (uint64 size, Gee.ArrayList<PartitionBar> partitions) {
+        public PartitionContainer (uint64 size, Gee.ArrayList<PartitionBlock> partitions) {
             Object (
                 partitions: partitions,
                 size: size

--- a/src/Widgets/PartitionBlock.vala
+++ b/src/Widgets/PartitionBlock.vala
@@ -5,7 +5,7 @@
  * Authored by: Michael Aaron Murphy <michael@system76.com>
  */
 
-public class Installer.PartitionBar : Gtk.Box {
+public class Installer.PartitionBlock : Adw.Bin {
     public signal void decrypted (InstallerDaemon.LuksCredentials credential);
 
     public Icon? icon { get; set; default = null; }
@@ -17,7 +17,7 @@ public class Installer.PartitionBar : Gtk.Box {
     public string? volume_group { get; private set; }
     public Gtk.Popover menu { get; private set; }
 
-    public PartitionBar (
+    public PartitionBlock (
         InstallerDaemon.Partition partition,
         string parent_path,
         uint64 sector_size,
@@ -56,13 +56,11 @@ public class Installer.PartitionBar : Gtk.Box {
         volume_group = (partition.filesystem == LVM) ? partition.current_lvm_volume_group : null;
 
         var image = new Gtk.Image () {
-            hexpand = true,
             halign = END,
             valign = END
         };
 
-        append (image);
-        hexpand = true;
+        child = image;
         tooltip_text = partition.device_path;
 
         add_css_class (partition.filesystem.to_string ());

--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -38,11 +38,11 @@ public class Installer.PartitionMenu : Gtk.Popover {
     private Gtk.Label custom_label;
     private Gtk.Label type_label;
     // A reference to the parent which owns this menu.
-    private PartitionBar partition_bar;
+    private PartitionBlock partition_bar;
 
     public PartitionMenu (string path, string parent, InstallerDaemon.FileSystem fs,
                           bool lvm, SetMount set_mount, UnsetMount unset_mount,
-                          MountSetFn mount_set, PartitionBar partition_bar) {
+                          MountSetFn mount_set, PartitionBlock partition_bar) {
         this.partition_bar = partition_bar;
         original_filesystem = fs;
         is_lvm = lvm;

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,7 +26,7 @@ vala_files = [
     'Widgets/DiskBar.vala',
     'Widgets/DiskGrid.vala',
     'Widgets/InstallTypeGrid.vala',
-    'Widgets/PartitionBar.vala',
+    'Widgets/PartitionBlock.vala',
     'Widgets/PartitionMenu.vala',
     'Widgets/Terminal.vala',
     'Widgets/VariantWidget.vala',


### PR DESCRIPTION
* Make it clearer that this is not the whole bar that contains all of the partitions
* Make it a Bin subclass since it only contains one widget
* Remove some unnecessary expands