### PR TITLE
meson: Set prefix to /usr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       env:
         DESTDIR: out
       run: |
-        meson setup build
+        meson setup build --prefix=/usr
         ninja -C build install
 
   lint:


### PR DESCRIPTION
The following error message in the CI means the sysconfdir variable is set to `etc`:

    session/meson.build:61:4: ERROR: File etc/xdg/autostart/org.gnome.SettingsDaemon.A11ySettings.desktop does not exist.

It points to `/etc` only when the prefix is set to `/usr` according to https://mesonbuild.com/Builtin-options.html:

    When the prefix is /usr: sysconfdir defaults to /etc, localstatedir defaults to /var, and sharedstatedir defaults to /var/lib