### PR TITLE
fix(DiskBar): simplify and prevent invalid constraints

### DIFF
--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -339,44 +339,186 @@ public class Installer.PartitioningView : AbstractInstallerView {
         InstallerDaemon.Disk[] physical_disks = {};
         InstallerDaemon.Disk[] logical_disks = {};
 
-        InstallerDaemon.Partition[] partitions = {};
-
-        var usage_1 = InstallerDaemon.PartitionUsage () {
-            tag = 1,
-            value = 30312
-        };
-
-        partitions += InstallerDaemon.Partition () {
-            device_path = "/dev/nvme0n1p1",
-            filesystem = InstallerDaemon.FileSystem.FAT32,
-            start_sector = 4096,
-            end_sector = 542966,
-            sectors_used = usage_1,
+        var partitions_0 = InstallerDaemon.Partition () {
+            device_path = "/dev/sda1",
+            filesystem = InstallerDaemon.FileSystem.NONE,
+            start_sector = 34,
+            end_sector = 32767,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 0,
+                value = 0
+            },
             current_lvm_volume_group = ""
         };
 
-        var usage_2 = InstallerDaemon.PartitionUsage () {
-            tag = 0,
-            value = 0
+        var partitions_1 = InstallerDaemon.Partition () {
+            device_path = "/dev/sda2",
+            filesystem = InstallerDaemon.FileSystem.NTFS,
+            start_sector = 32768,
+            end_sector = 3907026943,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 1,
+                value = 73486552
+            },
+            current_lvm_volume_group = ""
         };
 
-        partitions += InstallerDaemon.Partition () {
-            device_path = "/dev/nvme0n1p2",
+        physical_disks += InstallerDaemon.Disk () {
+            name = "ATA ST2000DM008-2FR1",
+            device_path = "/dev/sda",
+            sectors = 3907029168,
+            sector_size = 512,
+            rotational = true,
+            removable = false,
+            partitions = {partitions_0, partitions_1}
+        };
+
+        var partitions_2 = InstallerDaemon.Partition () {
+            device_path = "/dev/sdb1",
+            filesystem = InstallerDaemon.FileSystem.NTFS,
+            start_sector = 8192,
+            end_sector = 1953524143,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 1,
+                value = 14657872
+            },
+            current_lvm_volume_group = ""
+        };
+
+        physical_disks += InstallerDaemon.Disk () {
+            name = "ATA SAMSUNG HD103SJ",
+            device_path = "/dev/sdb",
+            sectors = 1953525168,
+            sector_size = 512,
+            rotational = true,
+            removable = false,
+            partitions = {partitions_2}
+        };
+
+        var partitions_3 = InstallerDaemon.Partition () {
+            device_path = "/dev/sdc1",
+            filesystem = InstallerDaemon.FileSystem.FAT32,
+            start_sector = 4096,
+            end_sector = 542966,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 1,
+                value = 30328
+            },
+            current_lvm_volume_group = ""
+        };
+
+        var partitions_4 = InstallerDaemon.Partition () {
+            device_path = "/dev/sdc2",
             filesystem = InstallerDaemon.FileSystem.LVM,
             start_sector = 542968,
-            end_sector = 976769070,
-            sectors_used = usage_2,
+            end_sector = 1562820270,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 0,
+                value = 0
+            },
             current_lvm_volume_group = "data"
         };
 
         physical_disks += InstallerDaemon.Disk () {
-            name = "Samsung SSD 970 EVO 500GB",
+            name = "ATA INTEL SSDSC2BX80",
+            device_path = "/dev/sdc",
+            sectors = 1562824368,
+            sector_size = 4096,
+            rotational = false,
+            removable = false,
+            partitions = {partitions_3, partitions_4}
+        };
+
+        var partitions_5 = InstallerDaemon.Partition () {
+            device_path = "/dev/nvme0n1p1",
+            filesystem = InstallerDaemon.FileSystem.FAT32,
+            start_sector = 2048,
+            end_sector = 1023999,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 1,
+                value = 58488
+            },
+            current_lvm_volume_group = ""
+        };
+
+        var partitions_6 = InstallerDaemon.Partition () {
+            device_path = "/dev/nvme0n1p2",
+            filesystem = InstallerDaemon.FileSystem.NONE,
+            start_sector = 1024000,
+            end_sector = 1286143,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 0,
+                value = 0
+            },
+            current_lvm_volume_group = ""
+        };
+
+        var partitions_7 = InstallerDaemon.Partition () {
+            device_path = "/dev/nvme0n1p3",
+            filesystem = InstallerDaemon.FileSystem.NTFS,
+            start_sector = 1286144,
+            end_sector = 1952003975,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 1,
+                value = 1624133504
+            },
+            current_lvm_volume_group = ""
+        };
+
+        var partitions_8 = InstallerDaemon.Partition () {
+            device_path = "/dev/nvme0n1p4",
+            filesystem = InstallerDaemon.FileSystem.NTFS,
+            start_sector = 1952004096,
+            end_sector = 1953519615,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 1,
+                value = 1305608
+            },
+            current_lvm_volume_group = ""
+        };
+
+        physical_disks += InstallerDaemon.Disk () {
+            name = "WDC WDS100T2B0C-00PXH0",
             device_path = "/dev/nvme0n1",
-            sectors = 976773168,
+            sectors = 1953525168,
             sector_size = 512,
             rotational = false,
             removable = false,
-            partitions = partitions
+            partitions = {partitions_5, partitions_6, partitions_7, partitions_8}
+        };
+
+        var partitions_9 = InstallerDaemon.Partition () {
+            device_path = "/dev/dm-0",
+            filesystem = InstallerDaemon.FileSystem.EXT4,
+            start_sector = 0,
+            end_sector = 1554268160,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 1,
+                value = 136999784
+            },
+            current_lvm_volume_group = ""
+        };
+
+        var partitions_10 = InstallerDaemon.Partition () {
+            device_path = "/dev/dm-1",
+            filesystem = InstallerDaemon.FileSystem.SWAP,
+            start_sector = 1554268161,
+            end_sector = 1562271745,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 0,
+                value = 0
+            },
+            current_lvm_volume_group = ""
+        };
+
+        logical_disks += InstallerDaemon.Disk () {
+            name = "LVM data",
+            device_path = "/dev/mapper/data",
+            sectors = 1562277302,
+            sector_size = 512,
+            rotational = false,
+            removable = false,
+            partitions = {partitions_9, partitions_10}
         };
 
         return InstallerDaemon.DiskInfo () {

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -411,7 +411,7 @@ public class Installer.PartitioningView : AbstractInstallerView {
             device_path = "/dev/sdc2",
             filesystem = InstallerDaemon.FileSystem.LVM,
             start_sector = 542968,
-            end_sector = 1562820270,
+            end_sector = 1062820270,
             sectors_used = InstallerDaemon.PartitionUsage () {
                 tag = 0,
                 value = 0

--- a/src/Views/PartitioningView.vala
+++ b/src/Views/PartitioningView.vala
@@ -521,6 +521,74 @@ public class Installer.PartitioningView : AbstractInstallerView {
             partitions = {partitions_9, partitions_10}
         };
 
+        var partitions_11 = InstallerDaemon.Partition () {
+            device_path = "/dev/nvme0n1p1",
+            filesystem = InstallerDaemon.FileSystem.FAT32,
+            start_sector = 4096,
+            end_sector = 542966,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 1,
+                value = 30312
+            },
+            current_lvm_volume_group = ""
+        };
+
+        var partitions_12 = InstallerDaemon.Partition () {
+            device_path = "/dev/nvme0n1p2",
+            filesystem = InstallerDaemon.FileSystem.LVM,
+            start_sector = 542968,
+            end_sector = 976769070,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 0,
+                value = 0
+            },
+            current_lvm_volume_group = "data"
+        };
+
+        physical_disks += InstallerDaemon.Disk () {
+            name = "Samsung SSD 970 EVO 500GB",
+            device_path = "/dev/nvme0n1",
+            sectors = 976773168,
+            sector_size = 512,
+            rotational = false,
+            removable = false,
+            partitions = {partitions_11, partitions_12}
+        };
+
+        var partitions_13 = InstallerDaemon.Partition () {
+            device_path = "/dev/dm-0",
+            filesystem = InstallerDaemon.FileSystem.EXT4,
+            start_sector = 0,
+            end_sector = 968220672,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 1,
+                value = 534569520
+            },
+            current_lvm_volume_group = ""
+        };
+
+        var partitions_14 = InstallerDaemon.Partition () {
+            device_path = "/dev/dm-1",
+            filesystem = InstallerDaemon.FileSystem.SWAP,
+            start_sector = 968220673,
+            end_sector = 976216065,
+            sectors_used = InstallerDaemon.PartitionUsage () {
+                tag = 0,
+                value = 0
+            },
+            current_lvm_volume_group = ""
+        };
+
+        logical_disks += InstallerDaemon.Disk () {
+            name = "LVM data",
+            device_path = "/dev/mapper/data",
+            sectors = 976226102,
+            sector_size = 512,
+            rotational = false,
+            removable = false,
+            partitions = {partitions_13, partitions_14}
+        };
+
         return InstallerDaemon.DiskInfo () {
             physical_disks = physical_disks,
             logical_disks = logical_disks

--- a/src/Widgets/DiskBar.vala
+++ b/src/Widgets/DiskBar.vala
@@ -147,6 +147,9 @@ public class Installer.DiskBar: Gtk.Box {
         }
 
         private void append_partition (Gtk.Widget widget, double percentage) {
+            // Truncate to 2 decimal places (round down), to ensure we don't go over 100% because of rounding errors
+            percentage = (int)(percentage * 100) / 100.0;
+
             widget.set_parent (this);
 
             var layout_manager = ((Gtk.ConstraintLayout) get_layout_manager ());

--- a/src/Widgets/DiskBar.vala
+++ b/src/Widgets/DiskBar.vala
@@ -231,7 +231,7 @@ public class Installer.DiskBar: Gtk.Box {
         public Legend.unused (uint64 size_in_bytes) {
             Object (
                 ppath: "unused",
-                size: size,
+                size: size_in_bytes,
                 fs: "unused"
             );
         }

--- a/src/Widgets/PartitionBlock.vala
+++ b/src/Widgets/PartitionBlock.vala
@@ -50,7 +50,7 @@ public class Installer.PartitionBlock : Adw.Bin {
         bind_property ("icon", image, "gicon", SYNC_CREATE);
     }
 
-    public uint64 get_partition_size () {
+    public uint64 get_partition_size_in_sectors () {
         return partition.end_sector - partition.start_sector;
     }
 }

--- a/src/Widgets/PartitionMenu.vala
+++ b/src/Widgets/PartitionMenu.vala
@@ -270,7 +270,7 @@ public class Installer.PartitionMenu : Gtk.Popover {
                 partition_path,
                 parent_disk,
                 mount,
-                partition_bar.get_partition_size (),
+                partition_bar.get_partition_size_in_sectors (),
                 (format_partition.active ? InstallerDaemon.MountFlags.FORMAT : 0)
                     + (is_lvm ? InstallerDaemon.MountFlags.LVM : 0),
                 filesystem,


### PR DESCRIPTION
Fixes #848 

Turns out the GTK constraint solver crashes (unpredictably? not always) when you give it invalid constraints, so I've made multiple improvements here to make the code clearer and remove most (all?) of the possibilities where we could be passing invalid constraints.

The main issue was clamping the percentages between 1% and 99%. Imagine a case where a disk has 3 partitions and the first two partitions use <1% of the disk and the 3rd partition uses >99%. We then clamp these percentages to `[1, 1, 99]`, which according to my calculations adds up to 101%. This makes the GTK constraint solver sad.

## Changes

- Add a more complicated mock disk layout to the test data in `PartitioningView.vala`, this allows reproducing the crashing issue in #848 prior to the other changes, and should help test for regressions in future.
- Make it clear in variable names and parameter names when we're using sectors vs actual size in bytes 
- Calculate percentages consistently based on sector sizes, and don't mix sectors/bytes in calculations
- Don't hardcode a 512 sector size
- Don't clamp the percentages (the image widget inside the partition block widget reserves space, so we don't get 0 sized widgets even with really tiny percentages)