### PR TITLE
debian: allow all architectures

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Standards-Version: 3.9.6
 Homepage: https://github.com/elementary/installer
 
 Package: io.elementary.installer
-Architecture: amd64
+Architecture: any
 Priority: extra
 Depends: distinst,
          espeak,
@@ -34,7 +34,7 @@ Description: Distribution installer
  Installs distros with ease, all installs are treated as OEM.
 
 Package: io.elementary.installer-session
-Architecture: amd64
+Architecture: all
 Priority: extra
 Depends: io.elementary.installer, lightdm
 Recommends: elementary-default-settings


### PR DESCRIPTION
This PR allows building the installer on all architectures.

Related to elementary/os#754. Tested on ARM64 server.