### PR TITLE
CheckView: fix screen reader accessibility

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -124,6 +124,24 @@
     }
 }
 
+list.background row {
+    border-radius: 0.5em;
+    transition: background 200ms ease-in-out;
+}
+
+list.background row + row {
+    margin-top: 1em;
+}
+
+list.background row:focus {
+    background: transparent;
+    color: inherit;
+}
+
+list.background row:focus-visible {
+    background: alpha(@text_color, 0.1);
+}
+
 navigation-view-page.partition levelbar block {
     border-radius: 0.333em;
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -89,6 +89,11 @@ public class Installer.MainWindow : Gtk.ApplicationWindow, PantheonWayland.Exten
         });
 
         child.realize.connect (() => {
+            // Can't access Inspector
+            if (Installer.App.test_mode) {
+                return;
+            }
+
             connect_to_shell ();
             make_centered ();
         });

--- a/src/Views/CheckView.vala
+++ b/src/Views/CheckView.vala
@@ -25,10 +25,10 @@ public class Installer.CheckView : AbstractInstallerView {
     // Minimum 1GB
     public const uint64 MINIMUM_MEMORY = 1 * ONE_GB;
 
-    private Gtk.Box message_box;
+    private Gtk.ListBox message_box;
     public bool has_messages {
         get {
-            return message_box.get_first_child () != null;
+            return message_box.get_row_at_index (0) != null;
         }
     }
 
@@ -70,10 +70,13 @@ public class Installer.CheckView : AbstractInstallerView {
         );
         specs_view.attach (get_comparison_grid (), 1, 2);
 
-        message_box = new Gtk.Box (VERTICAL, 32) {
+        message_box = new Gtk.ListBox () {
+            selection_mode = BROWSE,
             valign = CENTER,
             vexpand = true
         };
+        message_box.add_css_class (Granite.STYLE_CLASS_RICH_LIST);
+        message_box.add_css_class (Granite.STYLE_CLASS_BACKGROUND);
 
         title_area.append (image);
         title_area.append (title_label);
@@ -173,13 +176,28 @@ public class Installer.CheckView : AbstractInstallerView {
     }
 
     private class CheckView : Gtk.Grid {
+        public string title { get; construct; }
+        public string description { get; construct; }
+        public string icon_name { get; construct; }
+
+        private Gtk.Grid grid;
+
         public CheckView (string title, string description, string icon_name) {
+            Object (
+                title: title,
+                description: description,
+                icon_name: icon_name
+            );
+        }
+
+        construct {
             var image = new Gtk.Image.from_icon_name (icon_name) {
                 icon_size = LARGE,
-                valign = Gtk.Align.START
+                valign = START
             };
 
             var title_label = new Gtk.Label (title) {
+                mnemonic_widget = this,
                 wrap = true,
                 xalign = 0
             };
@@ -192,10 +210,22 @@ public class Installer.CheckView : AbstractInstallerView {
             };
 
             column_spacing = 12;
-
             attach (image, 0, 0, 1, 2);
             attach (title_label, 1, 0);
             attach (description_label, 1, 1);
+
+            // prevent reading all descriptions immediately
+            title_label.set_accessible_role (PRESENTATION);
+            description_label.set_accessible_role (PRESENTATION);
+
+            // prevent titles from being skipped
+            map.connect (() => {
+                parent.update_property (
+                    Gtk.AccessibleProperty.LABEL, title,
+                    Gtk.AccessibleProperty.DESCRIPTION, description,
+                    -1
+                );
+            });
         }
     }
 

--- a/src/Views/CheckView.vala
+++ b/src/Views/CheckView.vala
@@ -197,7 +197,6 @@ public class Installer.CheckView : AbstractInstallerView {
             };
 
             var title_label = new Gtk.Label (title) {
-                mnemonic_widget = this,
                 wrap = true,
                 xalign = 0
             };


### PR DESCRIPTION
Previously when the view was entered, the screen reader would read all of the descriptions of warning items, but sometimes skip their titles.

In this branch, the screen reader instead will announce a list of n items and read the first item (with its title and description). Then you can navigate to each item at your own pace or re-read items individually

Visually there should be no significant difference between this branch and main, but `focus-visible` styles were added so that you can see keyboard focus when the keyboard is being used to navigate

---

The grid of device specs remain inaccessible. This branch does not attempt to fix it