### PR TITLE
DiskGrid: improve screen reader labels

### DIFF
--- a/src/Widgets/DiskGrid.vala
+++ b/src/Widgets/DiskGrid.vala
@@ -32,6 +32,10 @@ public class Installer.DiskButton : Gtk.CheckButton {
         );
     }
 
+    class construct {
+        set_accessible_role (RADIO);
+    }
+
     construct {
         add_css_class ("image-button");
 
@@ -72,5 +76,11 @@ public class Installer.DiskButton : Gtk.CheckButton {
                 config.disk = disk_path;
             }
         });
+
+        update_property (
+            Gtk.AccessibleProperty.LABEL, disk_name,
+            Gtk.AccessibleProperty.DESCRIPTION, size_label.label,
+            -1
+        );
     }
 }


### PR DESCRIPTION
* Make sure that this is read as a radio not a checkbox
* Buttons are completely unlabeled in main for some reason. Make sure we set labels