### PR TITLE
README: remove reference to eol OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Installer
 [![Translation status](https://l10n.elementary.io/widgets/installer/-/svg-badge.svg)](https://l10n.elementary.io/projects/installer/?utm_source=widget)
 
-> Note: this is the installer for elementary OS 6 and newer. For the elementary OS 5.1 and older installer, see [Ubiquity](https://wiki.ubuntu.com/Ubiquity).
-
 ![Screenshot](data/screenshot-progress.png?raw=true)
 
 An installer for open-source operating systems. See the [wiki](https://github.com/elementary/installer/wiki) for goals, design spec, user flow, and details about each step.


### PR DESCRIPTION
This isn’t really relevant anymore since OS 5 is EOL