### PR TITLE
Install session files to wayland sessions

### DIFF
--- a/session/meson.build
+++ b/session/meson.build
@@ -15,7 +15,7 @@ install_data(
 
 install_data(
     'installer.desktop',
-    install_dir: get_option('datadir') / 'xsessions'
+    install_dir: get_option('datadir') / 'wayland-sessions'
 )
 
 install_data(


### PR DESCRIPTION
Fixes #689 

Installer daily has been disabled for Noble: https://code.launchpad.net/~elementary-os/+recipe/installer-daily