### PR TITLE
install: Add usr/lib/systemd/user

### DIFF
--- a/debian/io.elementary.installer-session.install
+++ b/debian/io.elementary.installer-session.install
@@ -1,5 +1,6 @@
 debian/10_elementary.conf /etc/lightdm/lightdm.conf.d/
 etc/xdg/autostart
+usr/lib/systemd/user
 usr/share/glib-2.0/schemas
 usr/share/gnome-session
 usr/share/wayland-sessions


### PR DESCRIPTION
Goes after https://github.com/elementary/installer/pull/929

Fixes the following build error by debhelper:

```
dh_missing --fail-missing
dh_missing: warning: usr/lib/systemd/user/gnome-session@installer.target.d/session.conf exists in debian/tmp but is not installed to anywhere
	The following debhelper tools have reported what they installed (with files per package)
	 * dh_install: io.elementary.installer (7), io.elementary.installer-session (5)
	 * dh_installdocs: io.elementary.installer (0), io.elementary.installer-session (0)
	If the missing files are installed by another tool, please file a bug against it.
	When filing the report, if the tool is not part of debhelper itself, please reference the
	"Logging helpers and dh_missing" section from the "PROGRAMMING" guide for debhelper (10.6.3+).
	  (in the debhelper package: /usr/share/doc/debhelper/PROGRAMMING.md.gz)
	Be sure to test with dpkg-buildpackage -A/-B as the results may vary when only a subset is built
	If the omission is intentional or no other helper can take care of this consider adding the
	paths to debian/not-installed.
dh_missing: warning: usr/lib/systemd/user/io.elementary.installer.compositor@wayland.service exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/lib/systemd/user/io.elementary.installer.service exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/lib/systemd/user/io.elementary.installer.target exists in debian/tmp but is not installed to anywhere
dh_missing: error: missing files, aborting
```
