### PR TITLE
Disable the donation reminder by GSD

### DIFF
--- a/session/installer-default-settings.gschema.override
+++ b/session/installer-default-settings.gschema.override
@@ -45,6 +45,9 @@ horiz-scroll-enabled=true
 natural-scroll=true
 scroll-method='two-finger-scrolling'
 
+[org.gnome.settings-daemon.plugins.housekeeping:Installer]
+donation-reminder-enabled=false
+
 [org.gnome.settings-daemon.plugins.screensaver-proxy:Installer]
 # Allows light-locker to accept DBus
 active=false


### PR DESCRIPTION
Same with https://github.com/elementary/default-settings/pull/365 but for the installer session.

Not sure if we see this notification during installation though.
