### PR TITLE
conf: Set installer as default session

### DIFF
--- a/debian/10_elementary.conf
+++ b/debian/10_elementary.conf
@@ -5,3 +5,4 @@
 allow-guest=false
 autologin-user=
 autologin-user-timeout=0
+user-session=installer


### PR DESCRIPTION
Fixes #945

Prior art: https://github.com/elementary/greeter/pull/747

## Checklist
- [x] Confirmed the iso built with the following change boots into the installer session instead of the demo session
  - Note: Changes made temporary in the os repository to test without packaging

```diff
ryonakano@fedora-host:~/work/elementary/os (main +=)$ git diff --staged
diff --git a/etc/config/includes.chroot/etc/lightdm/lightdm.conf.d/11_elementary.conf b/etc/config/includes.chroot/etc/lightdm/lightdm.conf.d/11_elementary.conf
new file mode 100644
index 0000000..3c431f1
--- /dev/null
+++ b/etc/config/includes.chroot/etc/lightdm/lightdm.conf.d/11_elementary.conf
@@ -0,0 +1,2 @@
+[Seat:*]
+user-session=installer
ryonakano@fedora-host:~/work/elementary/os (main +=)$
```

https://github.com/user-attachments/assets/0cb87237-095c-4c34-851a-d4ead5a8be3d
